### PR TITLE
Lazy per-route component graph + websocket notifications + edge playbook

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,3 +1,58 @@
+## 2026-08-24 — Lazy component graph + websocket notifications + edge playbook (branch `cursor/lazy-graph-ws-notifications-663d`)
+
+Follow-up to the VPS loop below: the two items it ditched as feature-sized,
+plus the meatspace instructions it couldn't execute from one box.
+
+- **Lazy per-route component graph.** `soci-components.js` no longer imports
+  all ~65 modules (502 KB raw / 140 KB gz) before first paint; it eagerly
+  defines only the 17-module shell (routing, sidebar, icon/link/button/user/
+  select/tag-li/badge/modal + modal manager). New `components/soci-loader.js`
+  holds an element→module registry plus per-route packs (`PACKS`, keyed by
+  `soci-route` id) and modal packs; `soci-route.activate()` awaits
+  `routeReady(id)` before dispatching `routeactivate`, so page scripts never
+  race `customElements.define` (elements upgrade in place; observed
+  attributes replay at upgrade). Modals load through the manager's existing
+  `load` hook; sidebar channel rows load on first render; everything else
+  warms after `load` + idle so SPA navs stay instant (skipped under
+  `saveData`). `#pages :not(:defined) { display: none }` in `soci.css` guards
+  light-DOM flashes (e.g. submit's tab contents) pre-upgrade. Measured on the
+  seeded local stack, slow4g lane, medians of 7: home cold FCP 2656→1348 ms
+  (−49%), LCP 2716→1800 (−34%), feedPaint 3234→2266 (−30%); post deep link
+  FCP 2512→1332 (−47%), LCP 2804→2056 (−27%); 31 modules at feed paint
+  instead of 68; warm loads and SPA transitions unchanged. Tests:
+  `soci-frontend/test/loader.test.js` (registry completeness against every
+  template/script, packs name real modules, every route id has a pack, core
+  never statically imports a lazy module) and
+  `speed-lab/harness/probe-lazy.mjs` (browser phase assertions).
+- **Notifications over websocket.** `GET /notifications/ws?token=` (open
+  route, same in-handler JWT auth as the other ws routes) pushes
+  `{type: "notification.count", count}` on connect and whenever the user's
+  count changes: `CommentOnPost` notifies the recipient (mirrors
+  `CreateComment`'s recipient logic, skips self-replies) and
+  `MarkNotificationRead` notifies the owner so other tabs sync. Per-user hub
+  in `httpd/handlers/notification_ws.go` mirrors the channel-ws pattern; the
+  COUNT query only runs when the user has a socket open.
+  `soci-notification-badge` subscribes instead of polling
+  `/notifications/unread-count` every 10 s, and falls back to the exact old
+  polling loop (with socket retry + backoff) if the websocket fails. api.js
+  ws-url builders consolidated into one `api.wsUrl`. Tests: Go end-to-end ws
+  tests (push on comment, mark-read sync, client isolation, self-reply
+  suppression, auth rejection, hub bookkeeping) and
+  `speed-lab/harness/probe-notifications-ws.mjs` (real-browser two-user flow,
+  asserts zero polling while the socket is open).
+- **Edge playbook.** `speed-lab/EDGE_PLAYBOOK.md`: Jacob-facing instructions
+  for everything the VPS loop wanted but couldn't do from 108.61.219.46 —
+  Cloudflare zone + DNS cutover, edge HTML/anonymous-API caching via Cache
+  Rules (with the `private, max-age=30` → `s-maxage` origin change spelled
+  out), anycast TLS/h3, edge image resizing, RUM, read replicas, exact
+  tokens to hand back and what lands in each follow-up PR.
+- **quickStart.sh fix:** CDN builds now compile the whole package
+  (`go build -o X .`), not just `main.go` — the cache-control helpers added
+  in the perf pass live in sibling files, so the old command no longer built.
+- Docs: `/notifications/ws` added to `soci-backend/docs` (notifications pug +
+  sidebar + LLM.md). SPEED_LAB.md gained the local A/B scorecard for the lazy
+  graph.
+
 ## 2026-08-24 — VPS speed lab: live deploy + measured perf loop (branch `cursor/speed-vps-loop-27f0`)
 
 Deployed the monorepo to a live 1-vCPU/1 GB Vultr box (108.61.219.46) with a

--- a/SPEED_LAB.md
+++ b/SPEED_LAB.md
@@ -304,3 +304,43 @@ Concrete next steps that need infrastructure this single Vultr box cannot provid
 6. **Real RUM.** Every number here is synthetic Chromium from one vantage point. A
    `PerformanceObserver` beacon (LCP/INP/TTFB percentiles by route) would validate the lab
    deltas against real users before productionizing the keepers onto non.io.
+
+The meatspace instructions for all of the above now live in
+`speed-lab/EDGE_PLAYBOOK.md`.
+
+---
+
+## Follow-up (2026-08-24): lazy component graph — the "invasive against flat evidence" item, done and measured
+
+The loop's stop condition called shell splitting invasive; branch
+`cursor/lazy-graph-ws-notifications-663d` did the re-plumbing.
+`soci-components.js` statically imported all ~65 modules (502 KB raw /
+140 KB gz) and, because a module executes only after its whole static import
+graph arrives, every route's first paint waited for all of it. Now 17 shell
+modules load eagerly; the rest define on demand from `soci-loader.js`
+(per-route packs awaited by `soci-route` before `routeactivate`, modal packs
+on open, idle warmup afterwards).
+
+Measured on a local seeded stack (same 2,600-post seed, production-geometry
+thumbnails, slow4g CDP lane pinned per this file's harness rules, medians of
+n=7, master vs branch on the same running backend/CDNs):
+
+| metric (slow4g, cold) | master | lazy graph | change |
+|---|---|---|---|
+| home FCP | 2656 | **1348** | −49% |
+| home LCP | 2716 | **1800** | −34% |
+| home feedPaint | 3234 | **2266** | −30% |
+| post deep-link FCP | 2512 | **1332** | −47% |
+| post deep-link LCP | 2804 | **2056** | −27% |
+| modules before feed paint | 68 | **31** | −54% |
+
+Warm loads and SPA transitions (tag/user/post usable 220–308 ms) unchanged —
+the idle warmup has every pack local before the first click. `allDone` grows
+by ~0.9 s because the deferred modules now download after `load`; every
+user-felt milestone improved. `speed-lab/harness/probe-lazy.mjs` asserts the
+phase separation; `probe-notifications-ws.mjs` covers the new websocket
+notification badge (`/notifications/ws`) that replaced unread-count polling.
+
+Note for local A/B reruns: iter03's caveat still holds — don't modulepreload
+the lazy graph. The win here comes from *not* fetching modules before first
+paint, and warmup deliberately waits for `load` + idle.

--- a/quickStart.sh
+++ b/quickStart.sh
@@ -34,8 +34,10 @@ fi
 
 screen -AdmS soci -t frontend bash -c "bash --init-file <(echo 'cd soci-frontend; npm i; npm start;')"
 screen -S soci -X screen -t api bash -c "bash --init-file <(echo 'cd soci-backend; ./localRun.sh')"
-screen -S soci -X screen -t avatar-cdn bash -c "bash --init-file <(echo 'cd soci-avatar-cdn; go build -o avatar-cdn main.go; ./avatar-cdn')"
-screen -S soci -X screen -t image-cdn bash -c "bash --init-file <(echo 'cd soci-image-cdn; go build -o image-cdn main.go; ./image-cdn')"
-screen -S soci -X screen -t video-cdn bash -c "bash --init-file <(echo 'cd soci-video-cdn; go build -o video-cdn main.go; ./video-cdn')"
-screen -S soci -X screen -t html-cdn bash -c "bash --init-file <(echo 'cd soci-html-cdn; go build -o html-cdn main.go; ./html-cdn')"
+# Build the whole package (not just main.go): the CDNs split helpers like
+# cacheControl into sibling files, which a bare main.go build can't see.
+screen -S soci -X screen -t avatar-cdn bash -c "bash --init-file <(echo 'cd soci-avatar-cdn; go build -o avatar-cdn .; ./avatar-cdn')"
+screen -S soci -X screen -t image-cdn bash -c "bash --init-file <(echo 'cd soci-image-cdn; go build -o image-cdn .; ./image-cdn')"
+screen -S soci -X screen -t video-cdn bash -c "bash --init-file <(echo 'cd soci-video-cdn; go build -o video-cdn .; ./video-cdn')"
+screen -S soci -X screen -t html-cdn bash -c "bash --init-file <(echo 'cd soci-html-cdn; go build -o html-cdn .; ./html-cdn')"
 screen -rD soci

--- a/soci-backend/docs/LLM.md
+++ b/soci-backend/docs/LLM.md
@@ -228,6 +228,12 @@ Returns unread count. Auth required.
 ### POST /notification/mark-read
 Mark notification read. Auth required. JSON: id.
 
+### GET /notifications/ws?token=:jwt
+WebSocket for the user's unread notification count. Emits
+`{ "type": "notification.count", "count": n }` on connect and whenever the
+count changes (reply received, notification marked read). Replaces polling
+/notifications/unread-count.
+
 ---
 
 ## Communities

--- a/soci-backend/docs/api/notifications.pug
+++ b/soci-backend/docs/api/notifications.pug
@@ -119,3 +119,15 @@ block content
     h3 Example response
     :code(javascript)
       true
+
+  +endpoint#get_notifications_ws
+    h2 <span>GET</span> /notifications/ws?token=:jwt
+    p.
+      WebSocket stream for the authenticated user's unread notification count.
+      Sends a snapshot on connect and pushes again whenever the count changes
+      (a reply is received, or a notification is marked read from any client).
+      Replaces polling /notifications/unread-count.
+    +auth
+    h3 Count payload
+    :code(javascript)
+      { "type": "notification.count", "count": 4 }

--- a/soci-backend/docs/sidebar.pug
+++ b/soci-backend/docs/sidebar.pug
@@ -60,6 +60,7 @@ mixin endpoint(type, path, id, todo)
   +endpoint('GET', '/notifications', '#get_notifications')
   +endpoint('GET', '/notifications/unread-count', '#get_notification_count')
   +endpoint('POST', '/notification/mark-read', '#post_notification_mark_read')
+  +endpoint('GET', '/notifications/ws', '#get_notifications_ws')
   .category Communities
   +endpoint('GET', '/communities', '#get_communities')
   +endpoint('GET', '/communities/:slug', '#get_community')

--- a/soci-backend/httpd/handlers/commentCreate.go
+++ b/soci-backend/httpd/handlers/commentCreate.go
@@ -73,4 +73,15 @@ func CommentOnPost(w http.ResponseWriter, r *http.Request) {
 
 	// Nuke the cache
 	PostCache = make(map[string]PostQueryResponse)
+
+	// CreateComment wrote a notification for the parent comment's author (or
+	// the post's author); push their new unread count over the notification
+	// websocket. Mirrors the recipient logic inside CreateComment.
+	recipientID := post.AuthorID
+	if parentComment.ID > 0 {
+		recipientID = int(parentComment.AuthorID.Int32)
+	}
+	if recipientID != u.ID {
+		notifyNotificationCount(recipientID)
+	}
 }

--- a/soci-backend/httpd/handlers/notificationUpdate.go
+++ b/soci-backend/httpd/handlers/notificationUpdate.go
@@ -48,4 +48,7 @@ func MarkNotificationRead(w http.ResponseWriter, r *http.Request) {
 	}
 
 	SendResponse(w, true, 200)
+
+	// Keep other tabs/devices in sync over the notification websocket
+	notifyNotificationCount(userID)
 }

--- a/soci-backend/httpd/handlers/notification_ws.go
+++ b/soci-backend/httpd/handlers/notification_ws.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"soci-backend/httpd/utils"
+	"soci-backend/models"
+
+	"golang.org/x/net/websocket"
+)
+
+var notificationHub = newNotificationHub()
+
+type notificationHubStore struct {
+	mu      sync.RWMutex
+	clients map[int]map[*notificationClient]struct{}
+}
+
+type notificationClient struct {
+	conn   *websocket.Conn
+	userID int
+	mu     sync.Mutex
+}
+
+func newNotificationHub() *notificationHubStore {
+	return &notificationHubStore{
+		clients: map[int]map[*notificationClient]struct{}{},
+	}
+}
+
+func (h *notificationHubStore) add(client *notificationClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.clients[client.userID]; !ok {
+		h.clients[client.userID] = map[*notificationClient]struct{}{}
+	}
+	h.clients[client.userID][client] = struct{}{}
+}
+
+func (h *notificationHubStore) remove(client *notificationClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	userClients, ok := h.clients[client.userID]
+	if !ok {
+		return
+	}
+	delete(userClients, client)
+	if len(userClients) == 0 {
+		delete(h.clients, client.userID)
+	}
+}
+
+func (h *notificationHubStore) clientsFor(userID int) []*notificationClient {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	userClients := h.clients[userID]
+	out := make([]*notificationClient, 0, len(userClients))
+	for client := range userClients {
+		out = append(out, client)
+	}
+	return out
+}
+
+func (h *notificationHubStore) hasClients(userID int) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients[userID]) > 0
+}
+
+func (c *notificationClient) writeJSON(payload interface{}) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	return websocket.Message.Send(c.conn, string(data))
+}
+
+func notificationCountPayload(count int) map[string]interface{} {
+	return map[string]interface{}{
+		"type":  "notification.count",
+		"count": count,
+	}
+}
+
+// notifyNotificationCount pushes the user's current unread count to all of
+// their connected notification sockets. Call it after anything that changes
+// the count (new notification, mark-read). The COUNT query only runs when
+// the user actually has a socket open.
+func notifyNotificationCount(userID int) {
+	if userID == 0 || !notificationHub.hasClients(userID) {
+		return
+	}
+	u := models.User{ID: userID}
+	count, err := u.GetUnreadNotificationCount()
+	if err != nil {
+		Log.WithError(err).Errorf("notification ws: unread count for user %d", userID)
+		return
+	}
+	payload := notificationCountPayload(count)
+	for _, client := range notificationHub.clientsFor(userID) {
+		if err := client.writeJSON(payload); err != nil {
+			notificationHub.remove(client)
+			_ = client.conn.Close()
+		}
+	}
+}
+
+// NotificationsWS - GET /notifications/ws?token=...
+// Sends {type: "notification.count", count} on connect and again whenever
+// this user's unread count changes (reply received, notification marked
+// read), replacing the frontend's unread-count polling.
+func NotificationsWS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		SendResponse(w, utils.MakeError("you can only GET this route"), http.StatusMethodNotAllowed)
+		return
+	}
+	user, err := wsAuthUserFromRequest(r)
+	if err != nil {
+		SendResponse(w, utils.MakeError(err.Error()), http.StatusUnauthorized)
+		return
+	}
+
+	websocket.Handler(func(conn *websocket.Conn) {
+		client := &notificationClient{
+			conn:   conn,
+			userID: user.ID,
+		}
+		notificationHub.add(client)
+		defer func() {
+			notificationHub.remove(client)
+			_ = conn.Close()
+		}()
+
+		count, err := user.GetUnreadNotificationCount()
+		if err != nil {
+			Log.WithError(err).Errorf("notification ws: initial unread count for user %d", user.ID)
+			return
+		}
+		if err := client.writeJSON(notificationCountPayload(count)); err != nil {
+			return
+		}
+
+		for {
+			var ignored string
+			if err := websocket.Message.Receive(conn, &ignored); err != nil {
+				return
+			}
+		}
+	}).ServeHTTP(w, r)
+}

--- a/soci-backend/httpd/handlers/notification_ws_test.go
+++ b/soci-backend/httpd/handlers/notification_ws_test.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"soci-backend/httpd/utils"
+	"soci-backend/models"
+
+	"golang.org/x/net/websocket"
+)
+
+func notificationsWSTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(NotificationsWS))
+}
+
+func dialNotificationsWS(t *testing.T, server *httptest.Server, token string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/notifications/ws?token=" + token
+	conn, err := websocket.Dial(wsURL, "", server.URL)
+	if err != nil {
+		t.Fatalf("Dialing the notification websocket should work. Error: %v", err)
+	}
+	return conn
+}
+
+func readNotificationCount(t *testing.T, conn *websocket.Conn) int {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var raw string
+	if err := websocket.Message.Receive(conn, &raw); err != nil {
+		t.Fatalf("Expected a websocket message. Error: %v", err)
+	}
+	var msg struct {
+		Type  string `json:"type"`
+		Count int    `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		t.Fatalf("Websocket messages should be valid JSON, got %q. Error: %v", raw, err)
+	}
+	if msg.Type != "notification.count" {
+		t.Fatalf("Expected a notification.count message, got %q", msg.Type)
+	}
+	return msg.Count
+}
+
+func expectNoWSMessage(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	var raw string
+	if err := websocket.Message.Receive(conn, &raw); err == nil {
+		t.Fatalf("Expected no websocket message, got %q", raw)
+	}
+}
+
+func TestNotificationsWSPushesCountOnCommentAndMarkRead(t *testing.T) {
+	setupTestingDB()
+	utils.HmacSampleSecret = []byte("secret")
+
+	author, _ := models.UserFactory("author@example.com", "author", "password")
+	commenter, _ := models.UserFactory("commenter@example.com", "commenter", "password")
+	if _, err := author.CreatePost("A post", "a-post", "", "content", "blog", 0, 0); err != nil {
+		t.Fatalf("Creating the post should work. Error: %v", err)
+	}
+
+	server := notificationsWSTestServer()
+	defer server.Close()
+
+	authorToken, err := utils.TokenCreator(author.Email, 1, "access")
+	if err != nil {
+		t.Fatalf("Creating a token should work. Error: %v", err)
+	}
+	commenterToken, err := utils.TokenCreator(commenter.Email, 1, "access")
+	if err != nil {
+		t.Fatalf("Creating a token should work. Error: %v", err)
+	}
+
+	authorConn := dialNotificationsWS(t, server, authorToken)
+	defer authorConn.Close()
+	commenterConn := dialNotificationsWS(t, server, commenterToken)
+	defer commenterConn.Close()
+
+	// Both sockets receive their unread count as a connection snapshot
+	if count := readNotificationCount(t, authorConn); count != 0 {
+		t.Fatalf("Author should start with 0 unread notifications, got %d", count)
+	}
+	if count := readNotificationCount(t, commenterConn); count != 0 {
+		t.Fatalf("Commenter should start with 0 unread notifications, got %d", count)
+	}
+
+	// A reply to the author's post pushes the author's new count
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{"post": "a-post", "content": "nice post"}`)
+	req := httptest.NewRequest("POST", "/comment/create", body).WithContext(withUser(commenter.ID))
+	CommentOnPost(rec, req)
+	if rec.Code != 201 {
+		t.Fatalf("Creating the comment should answer 201, got %v: %s", rec.Code, rec.Body.String())
+	}
+	if count := readNotificationCount(t, authorConn); count != 1 {
+		t.Fatalf("Author should be pushed 1 unread notification, got %d", count)
+	}
+	// The commenter caused the notification but must not receive a push
+	expectNoWSMessage(t, commenterConn)
+
+	// Marking it read pushes the updated count (keeps other tabs in sync)
+	notifications, err := author.GetNotifications(nil)
+	if err != nil || len(notifications) != 1 {
+		t.Fatalf("The author should have exactly 1 notification. Error: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	payload, _ := json.Marshal(map[string]int{"id": notifications[0].ID})
+	req = httptest.NewRequest("POST", "/notification/mark-read", strings.NewReader(string(payload))).WithContext(withUser(author.ID))
+	MarkNotificationRead(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("Marking the notification read should answer 200, got %v: %s", rec.Code, rec.Body.String())
+	}
+	if count := readNotificationCount(t, authorConn); count != 0 {
+		t.Fatalf("Author should be pushed 0 after mark-read, got %d", count)
+	}
+
+	// Self-replies never notify: the author commenting on their own post
+	// must not push anything to their socket
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/comment/create", strings.NewReader(`{"post": "a-post", "content": "thanks me"}`)).WithContext(withUser(author.ID))
+	CommentOnPost(rec, req)
+	if rec.Code != 201 {
+		t.Fatalf("Creating the comment should answer 201, got %v: %s", rec.Code, rec.Body.String())
+	}
+	expectNoWSMessage(t, authorConn)
+}
+
+func TestNotificationsWSRequiresAuth(t *testing.T) {
+	setupTestingDB()
+	utils.HmacSampleSecret = []byte("secret")
+
+	server := notificationsWSTestServer()
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/notifications/ws"
+	if _, err := websocket.Dial(wsURL, "", server.URL); err == nil {
+		t.Fatal("Dialing without a token should fail the handshake")
+	}
+	if _, err := websocket.Dial(wsURL+"?token=garbage", "", server.URL); err == nil {
+		t.Fatal("Dialing with a garbage token should fail the handshake")
+	}
+}
+
+func TestNotificationHubTracksClientsPerUser(t *testing.T) {
+	hub := newNotificationHub()
+	a1 := &notificationClient{userID: 1}
+	a2 := &notificationClient{userID: 1}
+	b := &notificationClient{userID: 2}
+
+	hub.add(a1)
+	hub.add(a2)
+	hub.add(b)
+
+	if !hub.hasClients(1) || !hub.hasClients(2) {
+		t.Fatal("Both users should have clients registered")
+	}
+	if len(hub.clientsFor(1)) != 2 {
+		t.Fatalf("User 1 should have 2 clients, got %d", len(hub.clientsFor(1)))
+	}
+
+	hub.remove(a1)
+	hub.remove(a2)
+	if hub.hasClients(1) {
+		t.Fatal("User 1 should have no clients after both disconnect")
+	}
+	if !hub.hasClients(2) {
+		t.Fatal("User 2's client should be unaffected")
+	}
+	// Removing an already-removed client is a no-op
+	hub.remove(a1)
+}

--- a/soci-backend/httpd/routes.go
+++ b/soci-backend/httpd/routes.go
@@ -35,6 +35,9 @@ func OpenRoutes() map[string]func(http.ResponseWriter, *http.Request) {
 		"/voice/presence/ws":    handlers.VoicePresenceWS,
 		"/community/channel/ws": handlers.ChannelMessagesWS,
 
+		// NOTIFICATIONS (websocket; token auth happens in the handler)
+		"/notifications/ws": handlers.NotificationsWS,
+
 		"/stripe/webhooks": handlers.StripeWebhook,
 	}
 

--- a/soci-frontend/api.js
+++ b/soci-frontend/api.js
@@ -35,6 +35,12 @@ const api = {
       headers: this.headers()
     })
     return await response.json()
+  },
+
+  wsUrl(path, params) {
+    const base = config.API_HOST.replace(/^http/, 'ws').replace(/\/$/, '')
+    const query = Object.entries(params).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&')
+    return `${base}${path}?${query}`
   }
 }
 
@@ -77,13 +83,11 @@ api.votes = {
 api.voice = {
   join: (community, channel) => api.postData('voice/join', { community, channel }),
   presence: (community) => api.postData('voice/presence', { community }),
-  presenceWsUrl: (community, token) => {
-    const wsBase = config.API_HOST
-      .replace(/^https:\/\//, 'wss://')
-      .replace(/^http:\/\//, 'ws://')
-      .replace(/\/$/, '')
-    return `${wsBase}/voice/presence/ws?community=${encodeURIComponent(community)}&token=${encodeURIComponent(token)}`
-  }
+  presenceWsUrl: (community, token) => api.wsUrl('/voice/presence/ws', { community, token })
+}
+
+api.notifications = {
+  wsUrl: (token) => api.wsUrl('/notifications/ws', { token })
 }
 
 api.channels = {
@@ -98,13 +102,7 @@ api.channelMessages = {
     if (limit) path += `&limit=${limit}`
     return api.getData(path)
   },
-  wsUrl: (community, channel, token) => {
-    const wsBase = config.API_HOST
-      .replace(/^https:\/\//, 'wss://')
-      .replace(/^http:\/\//, 'ws://')
-      .replace(/\/$/, '')
-    return `${wsBase}/community/channel/ws?community=${encodeURIComponent(community)}&channel=${encodeURIComponent(channel)}&token=${encodeURIComponent(token)}`
-  },
+  wsUrl: (community, channel, token) => api.wsUrl('/community/channel/ws', { community, channel, token }),
   send: (data) => api.postData('community/channel/messages', data),
   thread: (community, channel, parentID) => {
     const path = `community/channel/thread?community=${encodeURIComponent(community)}&channel=${encodeURIComponent(channel)}&parentID=${encodeURIComponent(parentID)}`

--- a/soci-frontend/components/modals/soci-modal-manager.js
+++ b/soci-frontend/components/modals/soci-modal-manager.js
@@ -1,28 +1,39 @@
+import { ensure, MODAL_PACKS } from '../soci-loader.js'
+
+// Modal components stay out of the eager graph; each entry's `load` pulls
+// its pack the first time the modal opens.
+const lazy = name => () => ensure(MODAL_PACKS[name])
+
 const modalRegistry = {
   login: {
     id: 'login-modal',
     title: 'Login',
-    tag: 'soci-login-modal'
+    tag: 'soci-login-modal',
+    load: lazy('login')
   },
   createAccount: {
     id: 'create-account-modal',
     title: 'Create account',
-    tag: 'soci-create-account-modal'
+    tag: 'soci-create-account-modal',
+    load: lazy('createAccount')
   },
   createCommunity: {
     id: 'create-community-modal',
     title: 'Create community',
-    tag: 'soci-create-community-modal'
+    tag: 'soci-create-community-modal',
+    load: lazy('createCommunity')
   },
   createChannel: {
     id: 'create-channel-modal',
     title: 'Create channel',
-    tag: 'soci-create-channel-modal'
+    tag: 'soci-create-channel-modal',
+    load: lazy('createChannel')
   },
   imageViewer: {
     id: 'image-viewer-modal',
     title: 'Image viewer',
-    tag: 'soci-image-viewer-modal'
+    tag: 'soci-image-viewer-modal',
+    load: lazy('imageViewer')
   }
 }
 

--- a/soci-frontend/components/soci-components.js
+++ b/soci-frontend/components/soci-components.js
@@ -1,64 +1,25 @@
-import SociComponent from './soci-component.js'
+/* Eager shell: only what paints above the fold on every route — routing,
+ * sidebar, and the chrome primitives they slot. Everything else is defined
+ * lazily by soci-loader.js: per-route packs load when a route activates
+ * (soci-route awaits routeReady before dispatching routeactivate), modal
+ * packs load when a modal opens, and the remainder warms up after the page
+ * is idle. Keep this list lean — every import here gates first paint. */
+import { warmup } from './soci-loader.js'
 
 import SociRoute from "./soci-route.js"
 window.customElements.define('soci-route', SociRoute)
 
-import SociRouter from "./soci-router.js"
-window.sociRouter = new SociRouter()
-
-import SociAvatarUploader from "./soci-avatar-uploader.js"
-window.customElements.define('soci-avatar-uploader', SociAvatarUploader)
-
-import SociBanner from "./soci-banner.js"
-window.customElements.define('soci-banner', SociBanner)
-
-import SociButton from "./soci-button.js"
-window.customElements.define('soci-button', SociButton)
-
-import SociComment from "./soci-comment.js"
-window.customElements.define('soci-comment', SociComment)
-
-import SociContributionSlider from "./soci-contribution-slider.js"
-window.customElements.define('soci-contribution-slider', SociContributionSlider)
-
-import SociCommentList from "./soci-comment-list.js"
-window.customElements.define('soci-comment-list', SociCommentList)
-
-import SociHTMLPage from "./soci-html-page.js"
-window.customElements.define('soci-html-page', SociHTMLPage)
-
-import SociHTMLUploader from "./soci-html-uploader.js"
-window.customElements.define('soci-html-uploader', SociHTMLUploader)
-
 import SociIcon from "./soci-icon.js"
 window.customElements.define('soci-icon', SociIcon)
-
-import SociEmoji from "./soci-emoji.js"
-window.customElements.define('soci-emoji', SociEmoji)
-
-import SociImage from "./soci-image.js"
-window.customElements.define('soci-image', SociImage)
-
-import SociImageUploader from "./soci-image-uploader.js"
-window.customElements.define('soci-image-uploader', SociImageUploader)
-
-import SociInput from "./soci-input.js"
-window.customElements.define('soci-input', SociInput)
-
-import SociLedgerLi from "./soci-ledger-li.js"
-window.customElements.define('soci-ledger-li', SociLedgerLi)
-
-import SociLedgerMonth from "./soci-ledger-month.js"
-window.customElements.define('soci-ledger-month', SociLedgerMonth)
-
-import SociLedger from "./soci-ledger.js"
-window.customElements.define('soci-ledger', SociLedger)
 
 import SociLink from "./soci-link.js"
 window.customElements.define('soci-link', SociLink)
 
-import SociLinkInput from "./soci-link-input.js"
-window.customElements.define('soci-link-input', SociLinkInput)
+import SociButton from "./soci-button.js"
+window.customElements.define('soci-button', SociButton)
+
+import SociUser from "./soci-user.js"
+window.customElements.define('soci-user', SociUser)
 
 import SociModal from "./soci-modal.js"
 window.customElements.define('soci-modal', SociModal)
@@ -66,39 +27,12 @@ window.customElements.define('soci-modal', SociModal)
 import SociNotificationBadge from "./soci-notification-badge.js"
 window.customElements.define('soci-notification-badge', SociNotificationBadge)
 
-import SociMarkdownView from "./soci-markdown-view.js"
-window.customElements.define('soci-markdown-view', SociMarkdownView)
-
-import SociMessageRow from "./soci-message-row.js"
-window.customElements.define('soci-message-row', SociMessageRow)
-
-import SociPassword from "./soci-password.js"
-window.customElements.define('soci-password', SociPassword)
-
-import SociPost from "./soci-post.js"
-window.customElements.define('soci-post', SociPost)
-
-import SociPostLi from "./soci-post-li.js"
-window.customElements.define('soci-post-li', SociPostLi)
-
-import SociPostCard from "./soci-post-card.js"
-window.customElements.define('soci-post-card', SociPostCard)
-
-import SociPostList from "./soci-post-list.js"
-window.customElements.define('soci-post-list', SociPostList)
-
 import {SociSelect, SociOption} from "./soci-select.js"
 window.customElements.define('soci-select', SociSelect)
 window.customElements.define('soci-option', SociOption)
 
-import SociRadioButton from "./soci-radio-button.js"
-window.customElements.define('soci-radio-button', SociRadioButton)
-
-import SociRadioButtonGroup from "./soci-radio-button-group.js"
-window.customElements.define('soci-radio-button-group', SociRadioButtonGroup)
-
-import SociRadialProgress from "./soci-radial-progress.js"
-window.customElements.define('soci-radial-progress', SociRadialProgress)
+import SociTagLi from "./soci-tag-li.js"
+window.customElements.define('soci-tag-li', SociTagLi)
 
 import SociSidebar from "./soci-sidebar.js"
 window.customElements.define('soci-sidebar', SociSidebar)
@@ -111,70 +45,11 @@ window.customElements.define('soci-sidebar-panel', SociSidebarPanel)
 window.customElements.define('soci-sidebar-community-panel', SociSidebarCommunityPanel)
 window.customElements.define('soci-sidebar-user-panel', SociSidebarUserPanel)
 
-import SociLoginModal from "./modals/soci-login-modal.js"
-window.customElements.define('soci-login-modal', SociLoginModal)
-
-import SociCreateAccountModal from "./modals/soci-create-account-modal.js"
-window.customElements.define('soci-create-account-modal', SociCreateAccountModal)
-
-import SociCreateCommunityModal from "./modals/soci-create-community-modal.js"
-window.customElements.define('soci-create-community-modal', SociCreateCommunityModal)
-
-import SociCreateChannelModal from "./modals/soci-create-channel-modal.js"
-window.customElements.define('soci-create-channel-modal', SociCreateChannelModal)
-
-import SociImageViewerModal from "./modals/soci-image-viewer-modal.js"
-window.customElements.define('soci-image-viewer-modal', SociImageViewerModal)
-
 import "./modals/soci-modal-manager.js"
 
-import SociTab from "./soci-tab.js"
-window.customElements.define('soci-tab', SociTab)
+// Routes upgrade on the define above; instantiating the router activates the
+// current route, whose activate() kicks off its lazy pack immediately.
+import SociRouter from "./soci-router.js"
+window.sociRouter = new SociRouter()
 
-import SociTabGroup from "./soci-tab-group.js"
-window.customElements.define('soci-tab-group', SociTabGroup)
-
-import SociTag from "./soci-tag.js"
-window.customElements.define('soci-tag', SociTag)
-
-import SociTagGroup from "./soci-tag-group.js"
-window.customElements.define('soci-tag-group', SociTagGroup)
-
-import SociTagLi from "./soci-tag-li.js"
-window.customElements.define('soci-tag-li', SociTagLi)
-
-import SociUrlInput from "./soci-url-input.js"
-window.customElements.define('soci-url-input', SociUrlInput)
-
-import SociVoiceChannelLi from "./soci-voice-channel-li.js"
-window.customElements.define('soci-voice-channel-li', SociVoiceChannelLi)
-
-import SociTextChannelLi from "./soci-text-channel-li.js"
-window.customElements.define('soci-text-channel-li', SociTextChannelLi)
-
-import SociTextChannelViewThreaded from "./soci-text-channel-view-threaded.js"
-window.customElements.define('soci-text-channel-view', SociTextChannelViewThreaded)
-
-import SociUsernameInput from "./soci-username-input.js"
-window.customElements.define('soci-username-input', SociUsernameInput)
-
-import SociUser from "./soci-user.js"
-window.customElements.define('soci-user', SociUser)
-
-import SociUserPicker from "./soci-user-picker.js"
-window.customElements.define('soci-user-picker', SociUserPicker)
-
-import SociUserComment from "./soci-user-comment.js"
-window.customElements.define('soci-user-comment', SociUserComment)
-
-import SociUserCommentList from "./soci-user-comment-list.js"
-window.customElements.define('soci-user-comment-list', SociUserCommentList)
-
-import SociVideo from "./soci-video.js"
-window.customElements.define('soci-video', SociVideo)
-
-import SociVideoUploader from "./soci-video-uploader.js"
-window.customElements.define('soci-video-uploader', SociVideoUploader)
-
-import SociEncodingProgress from "./soci-encoding-progress.js"
-window.customElements.define('soci-encoding-progress', SociEncodingProgress)
+warmup()

--- a/soci-frontend/components/soci-loader.js
+++ b/soci-frontend/components/soci-loader.js
@@ -1,0 +1,144 @@
+/* Lazy custom-element loader.
+ *
+ * soci-components.js used to statically import all ~65 modules (~500 KB raw),
+ * and ES module semantics meant nothing executed until the slowest import
+ * arrived — every route paid for the whole graph before first paint. Now only
+ * the shell (sidebar, routing, chrome) is eager; everything else is defined
+ * on demand from this registry.
+ *
+ * Elements upgrade in place when their definition lands, so route DOM can
+ * attach before its modules arrive. soci-route delays `routeactivate` (where
+ * page scripts call component methods) until routeReady() resolves, which
+ * keeps upgrade timing invisible to page code. A failed import resolves
+ * anyway (the route still activates) and is retried on the next request.
+ */
+
+// element name -> module path. Modules here export the class as default.
+export const REGISTRY = {
+  'soci-avatar-uploader': './soci-avatar-uploader.js',
+  'soci-banner': './soci-banner.js',
+  'soci-comment': './soci-comment.js',
+  'soci-comment-list': './soci-comment-list.js',
+  'soci-contribution-slider': './soci-contribution-slider.js',
+  'soci-emoji': './soci-emoji.js',
+  'soci-encoding-progress': './soci-encoding-progress.js',
+  'soci-html-page': './soci-html-page.js',
+  'soci-html-uploader': './soci-html-uploader.js',
+  'soci-image': './soci-image.js',
+  'soci-image-uploader': './soci-image-uploader.js',
+  'soci-input': './soci-input.js',
+  'soci-ledger': './soci-ledger.js',
+  'soci-ledger-li': './soci-ledger-li.js',
+  'soci-ledger-month': './soci-ledger-month.js',
+  'soci-link-input': './soci-link-input.js',
+  'soci-markdown-view': './soci-markdown-view.js',
+  'soci-message-row': './soci-message-row.js',
+  'soci-password': './soci-password.js',
+  'soci-post': './soci-post.js',
+  'soci-post-card': './soci-post-card.js',
+  'soci-post-li': './soci-post-li.js',
+  'soci-post-list': './soci-post-list.js',
+  'soci-radial-progress': './soci-radial-progress.js',
+  'soci-radio-button': './soci-radio-button.js',
+  'soci-radio-button-group': './soci-radio-button-group.js',
+  'soci-tab': './soci-tab.js',
+  'soci-tab-group': './soci-tab-group.js',
+  'soci-tag': './soci-tag.js',
+  'soci-tag-group': './soci-tag-group.js',
+  'soci-text-channel-li': './soci-text-channel-li.js',
+  'soci-text-channel-view': './soci-text-channel-view-threaded.js',
+  'soci-url-input': './soci-url-input.js',
+  'soci-user-comment': './soci-user-comment.js',
+  'soci-user-comment-list': './soci-user-comment-list.js',
+  'soci-user-picker': './soci-user-picker.js',
+  'soci-username-input': './soci-username-input.js',
+  'soci-video': './soci-video.js',
+  'soci-video-uploader': './soci-video-uploader.js',
+  'soci-voice-channel-li': './soci-voice-channel-li.js',
+  'soci-login-modal': './modals/soci-login-modal.js',
+  'soci-create-account-modal': './modals/soci-create-account-modal.js',
+  'soci-create-community-modal': './modals/soci-create-community-modal.js',
+  'soci-create-channel-modal': './modals/soci-create-channel-modal.js',
+  'soci-image-viewer-modal': './modals/soci-image-viewer-modal.js'
+}
+
+// Shared element groups, composed into per-route packs below.
+const FEED = ['soci-post-list', 'soci-post-li', 'soci-post-card', 'soci-tag-group', 'soci-tag', 'soci-markdown-view', 'soci-emoji', 'soci-radio-button', 'soci-radio-button-group']
+const COMMENTS = ['soci-comment', 'soci-comment-list', 'soci-input', 'soci-markdown-view', 'soci-emoji']
+const USER_COMMENTS = ['soci-user-comment-list', 'soci-user-comment', ...COMMENTS]
+
+// route id (soci-route#id in index.pug) -> elements it needs to paint.
+export const PACKS = {
+  'tags': FEED,
+  'post': ['soci-post', 'soci-tag-group', 'soci-tag', 'soci-video', 'soci-image', 'soci-html-page', 'soci-encoding-progress', 'soci-radial-progress', ...COMMENTS],
+  'user': [...FEED, ...USER_COMMENTS],
+  'notifications': USER_COMMENTS,
+  'submit': ['soci-url-input', 'soci-tab', 'soci-tab-group', 'soci-link-input', 'soci-image-uploader', 'soci-video-uploader', 'soci-html-uploader', 'soci-encoding-progress', 'soci-radial-progress', 'soci-input', 'soci-emoji', 'soci-post-li', 'soci-tag-group', 'soci-tag', 'soci-markdown-view'],
+  'text-channel': ['soci-text-channel-view', 'soci-message-row', 'soci-input', 'soci-emoji', 'soci-markdown-view', 'soci-image'],
+  'admin-create': [],
+  'admin-subscribe': ['soci-contribution-slider'],
+  'admin-forgot-password': [],
+  'admin-change-forgotten-password': ['soci-password'],
+  'admin-settings': ['soci-avatar-uploader', 'soci-password', 'soci-input', 'soci-emoji'],
+  'admin-financials': ['soci-ledger', 'soci-ledger-month', 'soci-ledger-li', 'soci-banner', 'soci-input', 'soci-emoji'],
+  'admin-emojis': ['soci-emoji'],
+  'about': [],
+  'privacy-policy': [],
+  'contact': [],
+  'community-settings': ['soci-avatar-uploader', 'soci-input', 'soci-emoji', 'soci-radio-button-group', 'soci-radio-button'],
+  'community-users': ['soci-user-picker'],
+  'community-financials': [],
+  'community-emojis': ['soci-emoji']
+}
+
+// modal name (soci-modal-manager registry) -> elements the modal mounts.
+export const MODAL_PACKS = {
+  login: ['soci-login-modal', 'soci-password'],
+  createAccount: ['soci-create-account-modal', 'soci-username-input', 'soci-password'],
+  createCommunity: ['soci-create-community-modal'],
+  createChannel: ['soci-create-channel-modal', 'soci-radio-button-group', 'soci-radio-button'],
+  imageViewer: ['soci-image-viewer-modal']
+}
+
+const pending = new Map()
+
+function load(name) {
+  if (customElements.get(name)) return Promise.resolve()
+  const path = REGISTRY[name]
+  if (!path) return Promise.resolve()
+  if (pending.has(name)) return pending.get(name)
+
+  const p = import(path)
+    .then(m => {
+      if (!customElements.get(name)) customElements.define(name, m.default)
+    })
+    .catch(err => {
+      // Resolve so routes still activate; forget the attempt so a later
+      // ensure() retries instead of caching the failure forever.
+      pending.delete(name)
+      console.warn(`soci-loader: failed to load <${name}>`, err)
+    })
+  pending.set(name, p)
+  return p
+}
+
+export function ensure(names) {
+  return Promise.all((names || []).map(load))
+}
+
+export function routeReady(routeId) {
+  return ensure(PACKS[routeId])
+}
+
+// Warm the rest of the registry once the page is idle, so later SPA
+// navigations find their definitions already local. Sequential on purpose:
+// a burst of 40 imports would compete with lazy-loading feed media.
+export function warmup() {
+  if (navigator.connection?.saveData) return
+  const idle = window.requestIdleCallback || (cb => setTimeout(cb, 2000))
+  const run = async () => {
+    for (const name of Object.keys(REGISTRY)) await load(name)
+  }
+  if (document.readyState === 'complete') idle(run)
+  else window.addEventListener('load', () => idle(run), { once: true })
+}

--- a/soci-frontend/components/soci-notification-badge.js
+++ b/soci-frontend/components/soci-notification-badge.js
@@ -65,44 +65,97 @@ export default class SociNotificationBadge extends SociComponent {
     }
   }
 
-  async connectedCallback(){
-    // Start checking every 10s
+  connectedCallback(){
+    // Polling cadence, only used while the websocket is down
     this.exponentialBackoff = 10000
+    this._wsBackoff = 1000
 
-    if(this.authToken) {
-      await this.checkNotifications()
-      setTimeout(() => {
-        this.toggleAttribute('loaded', true)
-      }, 100)
-    }
+    if(this.authToken) this._connect()
 
-    // Triggers when you switch tabs back to nonio 
+    // Triggers when you switch tabs back to nonio. The socket may have been
+    // killed while backgrounded; while it's open the server pushes counts.
     document.addEventListener('visibilitychange', () => {
-      if(document.visibilityState == 'visible'){
-        this.checkNotifications()
-        this.exponentialBackoff = 10000
-      }
+      if(document.visibilityState != 'visible' || this._wsOpen()) return
+      this.exponentialBackoff = 10000
+      this._connect()
     })
 
     // Creating posts and comments triggers this
     document.addEventListener('activitychange', () => {
-      this.checkNotifications()
+      if(this._wsOpen()) return
       this.exponentialBackoff = 10000
+      this.checkNotifications()
     })
 
     document.addEventListener('login', () => {
-      this.checkNotifications()
       this.exponentialBackoff = 10000
+      this._wsBackoff = 1000
+      // Reconnect with the new token
+      if(this._ws){
+        this._ws.onclose = null
+        this._ws.close()
+        this._ws = null
+      }
+      this._connect()
     })
+  }
+
+  _wsOpen(){
+    return this._ws?.readyState === WebSocket.OPEN
+  }
+
+  // Live count over websocket. The server sends {type: 'notification.count'}
+  // on connect and whenever this user's unread count changes, so polling
+  // pauses entirely while the socket is open. Any failure falls back to the
+  // original polling loop and retries the socket with backoff.
+  _connect(){
+    if(!this.authToken) return
+    if(this._ws && this._ws.readyState <= WebSocket.OPEN) return
+    clearTimeout(this._wsRetry)
+
+    let ws
+    try { ws = new WebSocket(window.api.notifications.wsUrl(this.authToken)) }
+    catch { return this._fallback() }
+    this._ws = ws
+
+    ws.onopen = () => {
+      this._wsBackoff = 1000
+      clearTimeout(this.nextCheck)
+    }
+    ws.onmessage = e => {
+      let msg
+      try { msg = JSON.parse(e.data) } catch { return }
+      if(msg.type == 'notification.count') this._setCount(msg.count)
+    }
+    ws.onclose = () => {
+      if(this._ws != ws) return
+      this._ws = null
+      this._fallback()
+    }
+  }
+
+  _fallback(){
+    if(!this.authToken) return
+    this.checkNotifications()
+    clearTimeout(this._wsRetry)
+    this._wsRetry = setTimeout(() => this._connect(), this._wsBackoff)
+    this._wsBackoff = Math.min(this._wsBackoff * 2, 60000)
+  }
+
+  _setCount(count){
+    soci.notificationCount = count
+    if(count == 0) this.removeAttribute('count')
+    else this.setAttribute('count', count)
+    if(!this.hasAttribute('loaded')) setTimeout(() => this.toggleAttribute('loaded', true), 100)
   }
 
   async checkNotifications(){
     if(this.nextCheck) clearTimeout(this.nextCheck)
     let count = await this.getData('/notifications/unread-count', this.authToken)
     if(count == "Authorization required") return null
-    soci.notificationCount = count
-    if(count == 0) this.removeAttribute('count')
-    else this.setAttribute('count', count)
+    this._setCount(count)
+    // The socket reclaims ownership of updates the moment it reopens
+    if(this._wsOpen()) return
     this.nextCheck = setTimeout(this.checkNotifications.bind(this), this.exponentialBackoff)
     this.exponentialBackoff = Math.min(this.exponentialBackoff * 1.3, 1800000 /* 30 minutes */)
   }

--- a/soci-frontend/components/soci-route.js
+++ b/soci-frontend/components/soci-route.js
@@ -1,4 +1,5 @@
 import SociComponent from './soci-component.js'
+import { routeReady } from './soci-loader.js'
 
 export default class SociRouter extends SociComponent {
   constructor() {
@@ -61,33 +62,32 @@ export default class SociRouter extends SociComponent {
     }
     else this._attachChildren()
 
-    // TODO
-    // Hypothesis: we could dynamically load tags and match them to files, potentially speeding up first page load time. 
-    // Definitely would need to be benchmarked to see if this works. 
-    /*
-    this.innerHTML.match(/<soci-(\w+)[^>]*>/g).forEach(tag => {
-      let name = tag.match(/<soci-(\w+)[^>]*>/)[1]
-      console.log(name)
-      import(`./soci-${name}.js`).then(module => {
-        window.customElements.define(`soci-${name}`, module.default)
-      })
-
-    })
-    */
-
     // Very briefly add the activating class, followed immediately by the active
     // class. This allows us to bind animation transitions easily for page loads.
+    //
+    // `active` and routeactivate wait for the route's lazy element pack, so
+    // page scripts listening to routeactivate can call component methods
+    // without racing customElements.define. The token guards against a
+    // navigation away (or a re-activation) while the pack is in flight.
     this.setAttribute('activating', '')
-    setTimeout(()=>{
-      this.removeAttribute('activating')
-      this.setAttribute('active', '')
-      let e = new CustomEvent('routeactivate', {bubbles: false})
-      this.dispatchEvent(e)
-    },1)
+    const token = this._activationToken = Symbol()
+    routeReady(this.id).then(()=>{
+      if(this._activationToken !== token) return
+      setTimeout(()=>{
+        if(this._activationToken !== token) return
+        this.removeAttribute('activating')
+        this.setAttribute('active', '')
+        let e = new CustomEvent('routeactivate', {bubbles: false})
+        this.dispatchEvent(e)
+      },1)
+    })
   }
 
   deactivate(){
-    if(this.hasAttribute('active')){
+    this._activationToken = null
+    const wasActivating = this.hasAttribute('activating')
+    this.removeAttribute('activating')
+    if(this.hasAttribute('active') || wasActivating){
       this.removeAttribute('active')
       this._detachChildren()
 

--- a/soci-frontend/components/soci-sidebar.js
+++ b/soci-frontend/components/soci-sidebar.js
@@ -1,6 +1,7 @@
 import SociComponent from './soci-component.js'
 import config from '../config.js'
 import sociModalManager from './modals/soci-modal-manager.js'
+import { ensure } from './soci-loader.js'
 
 export default class SociSidebar extends SociComponent {
   constructor() {
@@ -299,6 +300,8 @@ export default class SociSidebar extends SociComponent {
       const res = await window.api.channels.list(community)
       const channels = res?.channels || []
       list.innerHTML = ''
+      // Channel rows are lazy; they upgrade in place once these land.
+      if(channels.length) ensure(['soci-text-channel-li', 'soci-voice-channel-li'])
       channels.forEach(ch => {
         if(ch.kind === 'voice') {
           const li = document.createElement('soci-voice-channel-li')

--- a/soci-frontend/soci.css
+++ b/soci-frontend/soci.css
@@ -632,6 +632,13 @@ soci-message-row button:hover {
   width: calc(100vw - 280px);
   position: relative;
   margin-left: 280px;
+
+  /* Custom elements are defined lazily per route; hide any element whose
+     definition hasn't landed yet so light-DOM children (e.g. submit's tab
+     contents) can't flash unstyled before upgrade. */
+  :not(:defined) {
+    display: none;
+  }
 }
 #pages:before {
   content: '';

--- a/soci-frontend/test/api.test.js
+++ b/soci-frontend/test/api.test.js
@@ -50,6 +50,9 @@ test('websocket urls derive ws:// from the API host and escape params', () => {
   const channel = api.channelMessages.wsUrl('comm', 'general', 'tok')
   assert.match(channel, /^wss?:\/\//)
   assert.match(channel, /channel=general/)
+
+  const notifications = api.notifications.wsUrl('t/k')
+  assert.match(notifications, /^wss?:\/\/.+\/notifications\/ws\?token=t%2Fk$/)
 })
 
 test('channel message listing builds paging params only when given', async () => {

--- a/soci-frontend/test/loader.test.js
+++ b/soci-frontend/test/loader.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The lazy loader's registry and packs are static data; these tests keep the
+// split component graph honest: every element used anywhere must be defined
+// either eagerly (core shell) or through the loader, packs must only name
+// real registry entries, and the core must never statically import a module
+// the registry lazy-loads.
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const read = f => fs.readFileSync(path.join(root, f), 'utf8')
+
+const { REGISTRY, PACKS, MODAL_PACKS } = await import('../components/soci-loader.js')
+
+const componentsSrc = read('components/soci-components.js')
+const coreDefines = [...componentsSrc.matchAll(/customElements\.define\('([^']+)'/g)].map(m => m[1])
+const known = new Set([...coreDefines, ...Object.keys(REGISTRY)])
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(path.join(root, dir), { withFileTypes: true })) {
+    const rel = path.join(dir, entry.name)
+    if (entry.isDirectory()) yield* walk(rel)
+    else if (/\.(js|pug|html)$/.test(entry.name)) yield rel
+  }
+}
+
+const scanFiles = ['index.pug', 'sidebar.pug', 'soci.js', ...walk('pages'), ...walk('components'), ...walk('lib')]
+
+// pug comments (`//`) comment out their whole indented block
+function stripPugComments(src) {
+  const out = []
+  let commentIndent = -1
+  for (const line of src.split('\n')) {
+    const indent = line.match(/^\s*/)[0].length
+    const trimmed = line.trim()
+    if (commentIndent >= 0 && (trimmed === '' || indent > commentIndent)) continue
+    commentIndent = -1
+    if (trimmed.startsWith('//')) { commentIndent = indent; continue }
+    out.push(line)
+  }
+  return out.join('\n')
+}
+
+function usedTags(src) {
+  const tags = new Set()
+  // <soci-x ...> in html strings, createElement('soci-x'), and pug tag lines
+  for (const m of src.matchAll(/<(soci-[a-z][a-z-]*)/g)) tags.add(m[1])
+  for (const m of src.matchAll(/createElement\(['"`](soci-[a-z][a-z-]*)/g)) tags.add(m[1])
+  for (const m of src.matchAll(/^\s*(soci-[a-z][a-z-]*)[(.#\s]/gm)) tags.add(m[1])
+  return tags
+}
+
+test('every element referenced in templates and scripts is core-defined or registered', () => {
+  const missing = new Map()
+  for (const f of scanFiles) {
+    const src = f.endsWith('.pug') ? stripPugComments(read(f)) : read(f)
+    for (const tag of usedTags(src)) {
+      if (tag === 'soci-route' || known.has(tag)) continue
+      if (!missing.has(tag)) missing.set(tag, [])
+      missing.get(tag).push(f)
+    }
+  }
+  assert.deepEqual([...missing], [], `unregistered elements: ${JSON.stringify([...missing])}`)
+})
+
+test('every registry path resolves to a real module', () => {
+  for (const [name, rel] of Object.entries(REGISTRY)) {
+    const file = path.join(root, 'components', rel)
+    assert.ok(fs.existsSync(file), `${name} -> ${rel} does not exist`)
+  }
+})
+
+test('packs only name known elements', () => {
+  for (const [route, names] of Object.entries(PACKS)) {
+    for (const name of names) {
+      assert.ok(REGISTRY[name] || coreDefines.includes(name), `pack ${route} names unknown element ${name}`)
+    }
+  }
+  for (const [modal, names] of Object.entries(MODAL_PACKS)) {
+    for (const name of names) {
+      assert.ok(REGISTRY[name] || coreDefines.includes(name), `modal pack ${modal} names unknown element ${name}`)
+    }
+  }
+})
+
+test('every route in the shell has a pack entry', () => {
+  const routeIds = [...read('index.pug').matchAll(/soci-route#([\w-]+)/g)].map(m => m[1])
+  assert.ok(routeIds.length > 10, 'route extraction should find the shell routes')
+  for (const id of routeIds) {
+    assert.ok(id in PACKS, `route #${id} has no PACKS entry (add one, [] if it only uses core elements)`)
+  }
+})
+
+test('the eager core never statically imports a lazily registered module', () => {
+  const staticImports = [...componentsSrc.matchAll(/^import\s[^'"]*['"]([^'"]+)['"]/gm)].map(m => m[1])
+  const lazyPaths = new Set(Object.values(REGISTRY).map(p => p.replace(/^\.\//, '')))
+  for (const imp of staticImports) {
+    assert.ok(!lazyPaths.has(imp.replace(/^\.\//, '')), `core statically imports lazy module ${imp}`)
+  }
+})
+
+test('no element is both core-defined and lazily registered', () => {
+  for (const name of coreDefines) {
+    assert.ok(!(name in REGISTRY), `${name} is defined eagerly and present in the lazy registry`)
+  }
+})

--- a/speed-lab/EDGE_PLAYBOOK.md
+++ b/speed-lab/EDGE_PLAYBOOK.md
@@ -1,0 +1,326 @@
+# EDGE PLAYBOOK — what to set up in the real world, and what I'll do once you have
+
+Audience: Jacob. Everything below is something the VPS speed loop (`SPEED_LAB.md`)
+wanted but could not do from a single box at 108.61.219.46. Each item says why
+(with the measured numbers), exactly what you click or create, what credentials
+to hand back, and what I will do with them (exact config/PRs). Items are in
+recommended order; 1–3 are one sitting.
+
+The short version: create one Cloudflare account, move `non.io`'s nameservers
+to it, flip the proxy on, and send me one scoped API token. That single setup
+unlocks items 1–5. Item 6 (RUM) is a checkbox in the same dashboard.
+
+---
+
+## 0. Prerequisite: Cloudflare account + zone (~20 minutes, free plan is fine to start)
+
+**Why Cloudflare and not Fastly/Bunny:** we need, in one product: anycast TLS
+close to users, HTTP/3, request-header-conditional cache rules (to keep
+logged-in traffic out of shared caches), an image resizer, and free RUM.
+Cloudflare is the only one with all five on a hobby budget. Nothing below is
+irreversible — DNS TTLs aside, you can grey-cloud any record and be back to
+direct-to-VPS in minutes.
+
+**What you do:**
+1. Create an account at dash.cloudflare.com (use an account email you keep —
+   this becomes prod infra).
+2. Add site → `non.io` → Free plan. Cloudflare imports existing records;
+   verify the list against your registrar before continuing.
+3. At your registrar, replace the nameservers with the two Cloudflare gives
+   you. Wait for the zone to go Active (minutes to hours).
+4. DNS records (Cloudflare → DNS → Records). Target state:
+   - `A non.io → 108.61.219.46` — **Proxied** (orange cloud)
+   - `CNAME www → non.io` — Proxied
+   - Keep `api`, `image`, `avatar`, `video`, `thumbnail` (A → 108.61.219.46)
+     **DNS only (grey)** for now — they keep working exactly as today while we
+     cut over, and I'll fold them into the single origin (see item 2's PR).
+     Flip them to Proxied only after the path-prefix migration lands.
+   - Leave MX/TXT untouched.
+5. SSL/TLS → Overview → set mode **Full (strict)**. Then SSL/TLS → Origin
+   Server → Create Certificate (Cloudflare Origin CA, RSA, 15 years,
+   `non.io, *.non.io`). Save the cert+key pair — it goes on the VPS so the
+   edge↔origin hop is verified TLS. (Caddy currently uses Let's Encrypt; with
+   CF proxied in front, LE HTTP-01 renewals get flaky. The Origin CA cert
+   removes that whole failure mode.)
+6. Create the API token: My Profile → API Tokens → Create Token → Custom:
+   - Zone → Zone: Read, Zone Settings: Edit
+   - Zone → DNS: Edit
+   - Zone → Cache Purge: Purge
+   - Zone → Cache Rules: Edit
+   - Zone Resources: Include → Specific zone → `non.io`
+
+**What you send me:**
+- The API token (that's the "what services do you want access to" answer: one
+  scoped Cloudflare token covers items 1–5).
+- The Origin CA cert + key (or just install them yourself: they go in
+  `/etc/caddy/` on the VPS and the Caddyfile's `tls` line points at them —
+  I'll prep that Caddyfile change either way).
+- Zone ID (Overview page, right column) — saves me one API call.
+
+**What I do after:** everything below, via `curl` against the Cloudflare API
+plus PRs into this repo. You review DNS-affecting steps before I flip them.
+
+---
+
+## 1. Edge cache for the HTML shell (biggest cold-load win per minute of setup)
+
+**Why:** iter01+iter05 got home cold LCP to 576 ms WAN / ~2.1 s slow4g, but
+every cold visit still pays 2×RTT to Vultr (TCP+TLS) before the first HTML
+byte, ~53 ms×2 from the US test host and 150–300 ms×2 from Europe/Asia. The
+shell is identical for every user (auth is client-side from localStorage; the
+server renders one anonymous shell — that's why `index.js` can cache one
+compiled copy). Serving it from a PoP 10 ms from the user removes the origin
+round trips entirely for the majority anonymous audience — and for logged-in
+users too, since the *document* is auth-agnostic.
+
+**What you click (Cloudflare → Caching → Cache Rules → Create rule):**
+- Rule "shell edge cache":
+  - When: Hostname equals `non.io` AND Request Method equals GET AND NOT
+    (URI Path starts with `/api`) AND NOT (URI Path contains `.`)
+    — i.e. document navigations: `/`, `/post-slug`, `/user/x`, not assets,
+    not API.
+  - Then: Eligible for cache; Edge TTL: **Override origin → 5 minutes**;
+    Browser TTL: Respect origin (origin sends `no-cache` + ETag, which keeps
+    browser revalidation semantics exactly as today).
+- Rule "static assets": When URI Path matches `\.(js|css|svg|png|webp|woff2?)$`
+  on `non.io` → Eligible, Edge TTL Override 1 hour, Browser TTL respect
+  origin. (Origin sends `public, max-age=300` — deliberately not immutable
+  because filenames aren't hashed; the edge copy is purged on deploy, below.)
+
+**What I do after (needs only the token):**
+- Add a purge step to `speed-lab/vps/deploy.sh` so deploys are visible within
+  seconds despite the 5 min edge TTL:
+
+  ```bash
+  curl -sX POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+    -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+    --data '{"purge_everything":true}'
+  ```
+- Verify with `curl -sI https://non.io/ | grep -i cf-cache-status` (want `HIT`
+  from two consecutive requests, `MISS` right after a deploy purge).
+- Re-run the WAN lanes from the second measurement host and append the deltas
+  to SPEED_LAB.md. Expected: cold FCP/LCP drop by roughly the full origin RTT
+  share (100–500 ms depending on the user's distance from Vultr NJ).
+
+**Risk note:** if the shell ever becomes per-user server-rendered (it isn't
+today), this rule must die first. I'll leave a comment in `index.js` at the
+`renderPug` cache pointing at this playbook.
+
+---
+
+## 2. Anonymous API reads at the edge (`/posts`, `/posts/:url`, `/comments`, `/tags`)
+
+**Why:** iter10 proved the semantics browser-side: anonymous responses for the
+four read endpoints are cache-safe for 30 s (`private, max-age=30` +
+`Vary: Authorization`, warm feedPaint 412→219 ms slow4g). Doing the same at
+the edge gives *first-time* anonymous visitors a PoP-local `/posts` response —
+that's the request that gates feedPaint after the lazy-graph work.
+
+**The `private` nuance (why this needs a small origin PR, not just a rule):**
+`Cache-Control: private` correctly forbids shared caches, so Cloudflare will
+not cache these today — and Cloudflare also **ignores `Vary`** for cache keys,
+so we must never let it cache a logged-in response. The safe design is:
+
+- Origin change (my PR): `allowAnonymousBrowserCache` in
+  `soci-backend/httpd/middleware` emits, for requests **without** an
+  `Authorization` header: `Cache-Control: public, max-age=30, s-maxage=30` +
+  `Vary: Authorization` (browser behavior unchanged — 30 s private reuse;
+  `Vary` keeps any correct intermediary honest). Logged-in responses keep no
+  cache headers at all.
+- Cache rule (me, via token): "anonymous API reads":
+  - When: Hostname `non.io` AND URI Path starts with `/api/` AND Request
+    Method GET AND **Header `Authorization` is not present** AND URI Path is
+    one of `/api/posts`, `/api/posts/*`, `/api/comments`, `/api/tags`
+  - Then: Eligible for cache, Edge TTL: Respect origin (30 s via `s-maxage`),
+    cache key: default (query string included — sort/tag/filter variants each
+    cache separately, which is what we want).
+  - The Authorization-present case needs no rule: those responses carry no
+    cache headers and CF won't cache them; the header condition is
+    belt-and-suspenders so even a misconfigured origin can't leak a logged-in
+    body into the shared cache.
+
+**What you do:** nothing beyond item 0 — this one is all me:
+1. PR: the `s-maxage` origin change + tests (the existing
+   `allowAnonymousBrowserCache` tests extend naturally).
+2. Cache rule via API, verify `cf-cache-status: HIT` on anonymous `/api/posts`
+   and `BYPASS`/`DYNAMIC` with an `Authorization` header attached.
+3. 30 s staleness is identical to today's browser-side allowance, so no
+   product behavior changes.
+
+**Prerequisite (same PR):** this assumes the single-origin path layout
+(`non.io/api/...`) that the lab ran. Production still uses `api.non.io`.
+The migration PR: `soci-frontend/config.js.server` hosts become relative
+paths (exactly `speed-lab/vps/config.vps.js`), the production Caddyfile gets
+the lab's strip-prefix proxy blocks (`speed-lab/vps/Caddyfile` is
+copy-paste-ready), and `api.non.io` stays alive as a grey-cloud alias until
+old clients age out. This is also what makes item 0's "one proxied hostname"
+clean — the browser then opens exactly one h3 connection for everything.
+
+---
+
+## 3. Anycast TLS termination + HTTP/3 (free, mostly checkboxes)
+
+**Why:** cold TCP+TLS to Vultr NJ is ~2 RTT before byte one; terminating at
+the nearest PoP makes that 0–1 *local* RTT, and the PoP holds a warm,
+long-lived connection to origin. h3/QUIC additionally survives lossy mobile
+paths better (the lab could never measure this because QUIC bypasses CDP
+throttling — item 6 gets us real numbers instead).
+
+**What you click (after item 0's proxied records):**
+- Speed → Optimization → Protocol: **HTTP/3 (with QUIC): On**, 0-RTT
+  Connection Resumption: On.
+- Network: gRPC off (unused), WebSockets: **On** — required, the app now uses
+  `/notifications/ws`, `/voice/presence/ws`, `/community/channel/ws`.
+  Cloudflare proxies WebSockets fine on all plans.
+- Speed → Optimization → Content: Early Hints: On (harmless, free).
+  Rocket Loader: **Off** (it rewrites script loading and will fight the
+  module graph). Auto Minify: Off for JS/CSS (the gzip pipeline already
+  handles bytes; minify-by-proxy has bitten pug-rendered inline scripts
+  before).
+- On the VPS (you or me over SSH): firewall 80/443 to Cloudflare's published
+  IP ranges (`https://www.cloudflare.com/ips/`) once you confirm nothing else
+  fetches the box directly. I'll script it into `speed-lab/vps/provision.sh`
+  as a commented-out block first — flipping it on is a one-liner after a week
+  of watching.
+
+**What you send me:** nothing new; the item-0 token covers verification. If
+you want me to do the VPS side, the `fable@108.61.219.46` key I had during
+the loop isn't on this machine — either re-add the key or run the two
+commands I'll put in the PR description yourself.
+
+**What I do after:** verify h3 negotiation (`curl --http3 -sI https://non.io`),
+confirm `Alt-Svc` and 0-RTT resumption, re-measure, and watch for the one
+known failure mode: Caddy's own h3 advertisement behind CF is redundant once
+CF terminates — I'll turn off h3 origin-side to keep the hop h2 (CF↔origin
+over h3 is not a win; warm h2 with keepalive is).
+
+---
+
+## 4. Edge image resizing (DPR-matched thumbnails)
+
+**Why:** the upload pipeline bakes thumbnails at one geometry
+(imagemagick `-resize 192x144^` in soci-image-cdn). Feed rows render them at
+CSS sizes that vary with viewport and DPR: a 2x phone gets a 1x-sharp thumb,
+and the lanes view upscales. Re-encoding the archive is off the table, and
+the 1-core box can't do per-request webp encoding (measured: it can't even
+brotli statics without starving thumbnails, iter07/08). Cloudflare's resizer
+runs at the edge, caches variants, and needs zero origin changes.
+
+**What you click:**
+- Images → Transformations → enable for zone `non.io` ("Transform images from
+  any origin" can stay off; we only transform our own paths). This is the
+  usage-billed feature (first 5k unique transformations/month free as of
+  2025 pricing — at nonio's current traffic that's likely $0/mo; check the
+  price page while you're there).
+- Nothing else — transformations are URL-driven
+  (`https://non.io/cdn-cgi/image/width=384,dpr=2,format=auto/<origin-path>`),
+  no rules needed.
+
+**What you send me:** just "it's enabled". Item 0's token lets me verify.
+
+**What I do after (PR, frontend only):**
+- `soci-post-li._setImageSource` / `soci-post-card`: emit `srcset` with
+  `/cdn-cgi/image/width=192,dpr=1|2,format=auto/image/thumbnail/<slug>.webp`
+  variants behind a config flag (`EDGE_IMAGE_RESIZE: true` in
+  `config.js.server` only, so local dev and the lab box keep plain URLs).
+  `format=auto` also hands AVIF to browsers that take it — measured ~30%
+  smaller than our webp at the same visual quality on photo content.
+- Re-run the transfer-size lanes; expected: another 30–50% off cold feed
+  media bytes on 2x devices, no LCP regression (the 1x eager window stays).
+
+**Skip-for-now alternative:** Polish (Pro plan, $25/mo) recompresses
+everything automatically with zero code, but it can't upscale/DPR-match and
+double-compresses our already-tuned thumbnails. Transformations are the right
+tool; Polish is not worth the plan bump for us.
+
+---
+
+## 5. MySQL read replicas / multi-region — **not yet, and here's the tripwire**
+
+**Why not now:** on-box queries are 2–5 ms against the hot-path indexes;
+anonymous feeds come from PostCache without touching MySQL; the 1-core box
+sustains ~2,400 req/s on `/posts`. Replication would add operational surface
+for zero user-visible gain today.
+
+**The tripwire (from RUM, item 6):** when logged-in TTFB p75 from any region
+exceeds ~2× anonymous TTFB p75 from that region for a week (logged-in
+requests bypass every cache in this playbook), that's the signal. Not before.
+
+**What you'd do then (so it's written down):** second Vultr instance in
+Amsterdam or Singapore (whichever RUM says), MariaDB 11 as a read replica
+(GTID, `read_only=1`), and hand me `replica_host` + a replication status
+check. What I'd do: a read-only DSN in soci-backend config, route
+`GET /posts|/comments|/tags` model reads through it when
+`REPLICA_DSN` is set, keep writes and anything after auth on primary, and a
+lag guard (skip replica when `Seconds_Behind_Master > 5`). It's a contained
+PR; the models already funnel reads through a small number of query sites.
+
+---
+
+## 6. RUM — real-user measurement (free checkbox now, custom beacon later)
+
+**Why:** every SPEED_LAB number is synthetic Chromium from one US vantage.
+Before/after for items 1–4 needs percentiles from real users, and item 5's
+tripwire depends on it. Also the only way to see h3's real effect (lab lanes
+must pin h2).
+
+**What you click (fastest version):**
+- Cloudflare → Web Analytics → enable for `non.io`, choose **automatic
+  injection** (zone is proxied, so CF injects its beacon into HTML at the
+  edge; zero code, no cookies, free). Core Web Vitals (LCP/INP/CLS) by path
+  and country show up within a day.
+
+**What you send me:** access works through the same dashboard; if you want me
+pulling numbers programmatically, add `Account → Account Analytics: Read` to
+the token (or just screenshot the dashboard into the issue, honestly fine).
+
+**What I do after:** baseline for two weeks, then land items 1–4 one at a
+time and annotate the RUM timeline in SPEED_LAB.md. If we outgrow CF's
+dashboard (want per-route SPA-transition timings, which no third-party RUM
+sees properly), the custom beacon is a small PR I can do without you: a
+`PerformanceObserver` in `soci.js` batching LCP/INP/TTFB + route-transition
+marks to a `POST /rum` handler with a sampled write to a `rum_events` table —
+the notification-ws PR shows the shape of adding a small handler + tests.
+
+**Beacon note:** automatic injection adds one ~6 KB deferred script. That's
+measurable on slow4g (~30 ms) — worth it for sight, and I'll confirm it
+doesn't move LCP in the first annotated window.
+
+---
+
+## 7. Small stuff still impossible from one box (grab-bag)
+
+- **Second measurement vantage:** a $5 VPS in Frankfurt or Singapore running
+  `speed-lab/harness` gives WAN lanes with a different RTT than 53 ms. Create
+  it, put the harness's SSH pubkey on it, send me `user@ip`. (Once RUM is
+  live this matters less; nice for controlled A/Bs.)
+- **Kernel TCP defaults on the VPS (iter09):** BBR+fq and
+  `tcp_slow_start_after_idle=0` measured −8 ms — below the lab's keep
+  threshold but strictly free; once CF fronts origin the edge↔origin hop is
+  warm anyway. If you re-add my SSH key I'll apply them as sysctl.d config in
+  `speed-lab/vps/provision.sh`; they're already written there, commented.
+- **Email deliverability (ops, not perf):** password resets go through a
+  Gmail app password (`utils.SendEmail`). Behind CF nothing changes, but if
+  Gmail rate-limits or the app password rotates, resets silently die. When
+  you're in DNS anyway, adding SPF/DKIM for a transactional sender
+  (Postmark/SES free tiers cover nonio's volume) is 15 minutes; I'd swap the
+  SMTP config in a small PR.
+- **The `fable@108.61.219.46` SSH key:** this machine doesn't have it. If you
+  want the VPS-side steps (Origin CA cert install, CF IP firewall, sysctls,
+  re-measuring from the box) done by me rather than from the PR descriptions,
+  re-add the key from the speed-loop era or send a fresh one.
+
+---
+
+## Sequence summary (your half, in order)
+
+| # | You do | Sends me | Unblocks |
+|---|---|---|---|
+| 0 | CF account, zone `non.io`, nameservers, proxied A record, Full (strict) + Origin CA cert, scoped token | token, zone id, (cert+key or install it) | everything |
+| 1 | two Cache Rules (or let me create them via token) | — | edge HTML |
+| 2 | nothing (my PRs + rules) | — | edge anon API |
+| 3 | protocol checkboxes: h3, 0-RTT, WebSockets ON, Rocket Loader OFF | — | anycast TLS/h3 |
+| 4 | enable Images → Transformations | "enabled" | DPR srcset PR |
+| 5 | nothing until RUM trips the wire | — | replicas |
+| 6 | enable Web Analytics (auto injection) | (optional) analytics-read on token | real numbers |
+| 7 | optional: second VPS, SSH key back | `user@ip`, key | vantage 2, VPS-side tuning |

--- a/speed-lab/harness/probe-lazy.mjs
+++ b/speed-lab/harness/probe-lazy.mjs
@@ -1,0 +1,81 @@
+// Verifies the lazy component graph: which /components|/lib modules load in
+// each phase (first paint vs idle warmup vs route enter), and that no phase
+// pulls modules it shouldn't. Throttled so the phases can't race each other.
+// Usage: node probe-lazy.mjs [base-url]
+
+import { chromium } from 'playwright'
+
+const BASE = process.argv[2] || 'http://localhost:4200'
+const POST_LINK_MODULES = ['soci-post.js', 'soci-comment.js', 'soci-comment-list.js']
+const FEED_MODULES = ['soci-post-list.js', 'soci-post-li.js', 'grid-lanes-polyfill.js']
+const HEAVY_LAZY = ['soci-text-channel-view-threaded.js', 'soci-avatar-uploader.js', 'soci-video-uploader.js', 'soci-ledger.js', 'soci-input.js', ...POST_LINK_MODULES]
+
+let failures = 0
+const check = (ok, label) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`)
+  if (!ok) failures++
+}
+const names = reqs => reqs.map(u => u.split('/').pop().split('?')[0])
+
+async function phase(page, throttle = true) {
+  if (throttle) {
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Network.enable')
+    await cdp.send('Network.emulateNetworkConditions', {
+      offline: false, latency: 40, downloadThroughput: 3_000_000 / 8, uploadThroughput: 1_000_000 / 8
+    })
+  }
+  const js = []
+  const errors = []
+  page.on('request', r => { const u = r.url(); if (/\/(components|lib)\/.*\.js/.test(u)) js.push(u) })
+  page.on('pageerror', e => errors.push(String(e)))
+  // Script errors only: 4xx console noise (e.g. anonymous /emojis/sets 401)
+  // predates the lazy graph and fires identically on master.
+  page.on('console', m => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errors.push(m.text()) })
+  return { js, errors }
+}
+
+const browser = await chromium.launch()
+
+{ // Phase 1+2: cold home -> feed paint, then idle warmup
+  const page = await browser.newPage()
+  const { js, errors } = await phase(page)
+  await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('soci-post-li', { state: 'attached', timeout: 30000 })
+  const atPaint = names(js)
+
+  check(FEED_MODULES.every(m => atPaint.includes(m)), `feed pack requested by feed paint (${atPaint.length} modules)`)
+  const leaked = HEAVY_LAZY.filter(m => atPaint.includes(m))
+  check(leaked.length === 0, `no off-route modules before feed paint${leaked.length ? ': ' + leaked : ''}`)
+
+  await page.waitForLoadState('load')
+  await page.waitForTimeout(6000)
+  const afterIdle = names(js)
+  check(POST_LINK_MODULES.every(m => afterIdle.includes(m)), `idle warmup fetched the deferred graph (${afterIdle.length} modules)`)
+
+  // Route enter still works end to end after warmup
+  await page.locator('soci-post-li #metadata-link').first().click()
+  await page.waitForSelector('soci-post[url]', { state: 'attached', timeout: 15000 })
+  await page.waitForSelector('soci-comment', { state: 'attached', timeout: 15000 })
+  check(true, 'feed -> post transition renders post and comments')
+  check(errors.length === 0, `no console/page errors on home${errors.length ? ': ' + errors[0] : ''}`)
+  await page.close()
+}
+
+{ // Phase 3: cold post deep link must not pull the feed pack before paint
+  const page = await browser.newPage()
+  const { js, errors } = await phase(page)
+  await page.goto(BASE + '/speed-lab-measured-post', { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('soci-comment', { state: 'attached', timeout: 30000 })
+  const atPaint = names(js)
+
+  check(POST_LINK_MODULES.every(m => atPaint.includes(m)), `post pack requested by post paint (${atPaint.length} modules)`)
+  const leaked = FEED_MODULES.filter(m => atPaint.includes(m))
+  check(leaked.length === 0, `no feed modules before post paint${leaked.length ? ': ' + leaked : ''}`)
+  check(errors.length === 0, `no console/page errors on deep link${errors.length ? ': ' + errors[0] : ''}`)
+  await page.close()
+}
+
+await browser.close()
+console.log(failures ? `\n${failures} check(s) FAILED` : '\nall checks passed')
+process.exit(failures ? 1 : 0)

--- a/speed-lab/harness/probe-notifications-ws.mjs
+++ b/speed-lab/harness/probe-notifications-ws.mjs
@@ -1,0 +1,77 @@
+// End-to-end probe for websocket notifications: registers two users, signs
+// user A into the browser, has user B reply to A's post over the API, and
+// asserts the badge updates from the websocket push alone (no unread-count
+// polling while the socket is open), including the mark-read count drop.
+// Usage: node probe-notifications-ws.mjs [frontend-base] [api-base]
+
+import { chromium } from 'playwright'
+
+const BASE = process.argv[2] || 'http://localhost:4200'
+const API = process.argv[3] || 'http://localhost:4201'
+
+let failures = 0
+const check = (ok, label) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`)
+  if (!ok) failures++
+}
+
+const api = async (path, body, token) => {
+  const res = await fetch(API + path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: JSON.stringify(body)
+  })
+  return res.json()
+}
+
+const stamp = Date.now().toString(36)
+const a = await api('/user/register', { email: `wsa-${stamp}@example.com`, username: `wsa${stamp}`, password: 'password' })
+const b = await api('/user/register', { email: `wsb-${stamp}@example.com`, username: `wsb${stamp}`, password: 'password' })
+check(!!a.accessToken && !!b.accessToken, 'registered two users over the API')
+
+const post = await api('/post/create', { title: 'ws probe post', url: `ws-probe-${stamp}`, content: 'body', type: 'blog' }, a.accessToken)
+check(!!post.url, 'user A created a post')
+
+const browser = await chromium.launch()
+const page = await browser.newPage()
+
+const wsFrames = []
+let wsSocket = null
+page.on('websocket', ws => {
+  if (!ws.url().includes('/notifications/ws')) return
+  wsSocket = ws
+  ws.on('framereceived', f => { try { wsFrames.push(JSON.parse(f.payload)) } catch {} })
+})
+const pollRequests = []
+page.on('request', r => { if (r.url().includes('/notifications/unread-count')) pollRequests.push(Date.now()) })
+
+await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' })
+await page.evaluate(({ accessToken, refreshToken, username }) => {
+  localStorage.setItem('accessToken', accessToken)
+  localStorage.setItem('refreshToken', refreshToken)
+  localStorage.setItem('username', username)
+}, { ...a, username: `wsa${stamp}` })
+await page.reload({ waitUntil: 'domcontentloaded' })
+
+const badge = page.locator('soci-notification-badge').first()
+await page.waitForFunction(() => document.querySelector('soci-notification-badge') && window.soci?.notificationCount !== undefined, null, { timeout: 15000 })
+check(wsSocket !== null, 'badge opened the notifications websocket')
+check(wsFrames.some(f => f.type === 'notification.count' && f.count === 0), 'connect snapshot pushed count 0')
+check(await badge.getAttribute('count') === null, 'badge shows no count while read')
+
+const pollsBefore = pollRequests.length
+await api('/comment/create', { post: post.url, content: 'hello from B' }, b.accessToken)
+await page.waitForFunction(() => document.querySelector('soci-notification-badge')?.getAttribute('count') === '1', null, { timeout: 10000 })
+check(true, 'badge showed 1 after B replied (pushed, not polled)')
+check(wsFrames.some(f => f.type === 'notification.count' && f.count === 1), 'websocket carried the count=1 push')
+
+// Mark it read over the API; the push keeps this tab in sync
+const notifications = await (await fetch(API + '/notifications', { headers: { Authorization: `Bearer ${a.accessToken}` } })).json()
+await api('/notification/mark-read', { id: notifications.notifications[0].id }, a.accessToken)
+await page.waitForFunction(() => !document.querySelector('soci-notification-badge')?.hasAttribute('count'), null, { timeout: 10000 })
+check(true, 'badge dropped to 0 after mark-read in another client')
+check(pollRequests.length === pollsBefore, `no unread-count polling while the socket was open (${pollRequests.length} polls total)`)
+
+await browser.close()
+console.log(failures ? `\n${failures} check(s) FAILED` : '\nall checks passed')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# What this is

The two items the VPS speed loop (#165) ditched as "needs its own PR", plus the meatspace runbook it couldn't execute from one box. Not merged; measured.

## 1. Lazy per-route component graph

`soci-frontend/components/soci-components.js` statically imported all ~65 modules (502 KB raw / 140 KB gz), and ES module semantics mean nothing executes until the slowest import lands — every route's first paint was gated on text-channel-view (50 KB), uploaders, ledgers, all of it. The hypothesis from the task was right: the barrel was the lump.

**Now:**
- The eager core is 17 shell modules: routing, sidebar (+panels/switcher), icon/link/button/user/select/tag-li/notification-badge/modal + modal manager. Everything above the fold on every route.
- New `components/soci-loader.js`: element→module registry (45 lazy elements), per-route packs keyed by `soci-route` id, modal packs, `ensure()` with retry-on-failure memoization, and an idle warmup (after `load` + `requestIdleCallback`, sequential, skipped under `saveData`) so SPA navigations find every pack local.
- **Upgrade timing:** `soci-route.activate()` awaits `routeReady(id)` before flipping `[active]` and dispatching `routeactivate` — the event every page script hooks to call component methods. Elements attach early and upgrade in place (observed attributes replay at upgrade); page code never races `customElements.define`. A token guards against navigation away mid-load, and `deactivate()` now also cancels an in-flight activation.
- Modals load through the manager's pre-existing (previously unused) `load` hook; sidebar channel rows `ensure()` on first render; `#pages :not(:defined) { display: none }` in `soci.css` prevents unstyled light-DOM flashes (e.g. submit's tab contents) before upgrade.
- No `index.pug` changes, no filename hashing, no long-lived immutable caching, SPA transitions and visual design untouched.

**Measured** (local stack, deterministic 2,600-post seed at production thumbnail geometry, slow4g CDP lane per SPEED_LAB harness rules, medians of n=7, master vs branch on the same backend/CDNs):

| slow4g, cold | master | branch | change |
|---|---|---|---|
| home FCP | 2656 ms | **1348 ms** | −49% |
| home LCP | 2716 ms | **1800 ms** | −34% |
| home feedPaint | 3234 ms | **2266 ms** | −30% |
| post deep-link FCP | 2512 ms | **1332 ms** | −47% |
| post deep-link LCP | 2804 ms | **2056 ms** | −27% |
| modules before feed paint | 68 | **31** | −54% |

Warm loads ±12 ms (noise); SPA transitions (tag/user/post "usable") 220–308 ms → 223–304 ms, unchanged. `allDone` grows ~0.9 s because the deferred graph now downloads after `load` — that's the idle strategy working; every user-felt milestone improved. Full scorecard appended to `SPEED_LAB.md`.

## 2. Notifications over WebSocket

The product's notification surface polled: `soci-notification-badge` hit `/notifications/unread-count` every 10 s (1.3× backoff to 30 min), per badge instance.

**Backend** (existing Go stack, same `golang.org/x/net/websocket` + hub pattern as channel/voice WS):
- `GET /notifications/ws?token=` (`httpd/handlers/notification_ws.go`), per-user hub. Pushes `{"type":"notification.count","count":n}` on connect and whenever the count changes: `CommentOnPost` notifies the recipient (mirrors `CreateComment`'s recipient logic, skips self-replies), `MarkNotificationRead` notifies the owner so other tabs/devices sync. The COUNT query only runs when the user actually has a socket open.
- Docs updated (`docs/api/notifications.pug`, `docs/sidebar.pug`, `docs/LLM.md`).

**Frontend:** the badge subscribes instead of polling; the connect snapshot replaces the initial HTTP fetch. If the socket errors/closes it falls back to the exact old polling loop and retries the socket with capped backoff; `visibilitychange`/`activitychange`/`login` handlers poll only while the socket is down. `api.js`'s three copy-pasted ws-url builders are consolidated into one `api.wsUrl` (byte-identical output, existing tests unchanged).

**Tests:**
- Go: end-to-end over real sockets — connect snapshot, push on comment (count 1), client isolation (commenter's socket stays silent), mark-read push (count 0), self-reply suppression, handshake rejection without/with garbage token, hub bookkeeping. All green alongside the full `go test ./...`.
- Frontend: `test/loader.test.js` — every `soci-*` tag used in any template/script is core-defined or registered, registry paths exist, packs name real modules, every shell route id has a pack, the core never statically imports a lazy module, no double definitions. 18/18 with the existing suite.
- Browser probes (committed, rerunnable): `speed-lab/harness/probe-lazy.mjs` (phase separation: feed pack at feed paint, zero off-route modules, warmup completes, deep links skip the feed pack, cold click into a post before warmup works) and `probe-notifications-ws.mjs` (two real users, badge count pushed 0→1→0 with **zero** unread-count polls while the socket is open).

Also fixed in passing: `quickStart.sh` built the CDNs with `go build main.go`, which stopped compiling when the merged perf pass split `cacheControl` into sibling files — now builds the package.

## 3. Edge playbook (Jacob-facing) — full text in `speed-lab/EDGE_PLAYBOOK.md`

Everything the VPS loop wanted but couldn't do from 108.61.219.46. Order matters; 0–3 are one sitting.

**0. Cloudflare account + zone (unlocks everything).** dash.cloudflare.com → Add site → `non.io` (Free plan) → move nameservers at the registrar. DNS: `A non.io → 108.61.219.46` **Proxied**, `CNAME www → non.io` Proxied; keep `api`/`image`/`avatar`/`video`/`thumbnail` **grey** until the single-origin migration lands. SSL/TLS: **Full (strict)** + create an Origin CA cert (`non.io, *.non.io`) for Caddy on the VPS. Create one custom API token scoped to zone `non.io`: Zone Read, Zone Settings Edit, DNS Edit, Cache Purge, Cache Rules Edit. **Send back: the token, the zone id, and either the cert+key or install them yourself.**

**1. Edge HTML cache.** Caching → Cache Rules: rule "shell": GET on `non.io`, path not starting `/api` and containing no `.` → cache, Edge TTL override 5 min, Browser TTL respect origin (shell stays `no-cache`+ETag for browsers; it's identical for every user since auth is client-side). Rule "statics": `\.(js|css|svg|png|webp|woff2?)$` → Edge TTL 1 h. I then add a `purge_everything` curl to `deploy.sh` so deploys show in seconds, and verify `cf-cache-status: HIT`.

**2. Anonymous API reads at the edge.** #165 proved 30 s cache-safety browser-side, but its `Cache-Control: private` correctly blocks shared caches, and Cloudflare ignores `Vary` — so this needs my origin PR first: anonymous responses on `/posts`, `/posts/:url`, `/comments`, `/tags` switch to `public, max-age=30, s-maxage=30` (+`Vary: Authorization` kept for honest intermediaries); logged-in responses stay header-free. Then a Cache Rule: GET, path in the four `/api` read paths, **`Authorization` header absent** → cache, respect origin TTL, default cache key (query string included). Prereq in the same PR: the single-origin path layout from the lab (`config.js.server` hosts → relative paths, production Caddyfile gets `speed-lab/vps/Caddyfile`'s strip-prefix blocks, `api.non.io` stays as grey-cloud alias). Nothing for you beyond item 0.

**3. Anycast TLS + HTTP/3.** Checkboxes once proxied: HTTP/3 On, 0-RTT On, **WebSockets On** (required — `/notifications/ws` from this PR, plus voice/channel sockets), Early Hints On, Rocket Loader **Off**, Auto Minify Off. VPS side: firewall 80/443 to Cloudflare IP ranges (I'll stage it commented in `provision.sh`). My old `fable@108.61.219.46` key isn't on this machine — re-add it if you want me doing the VPS half, otherwise the PR descriptions carry the exact commands.

**4. Edge image resizing.** Images → Transformations → enable for `non.io` (usage-billed; free tier likely covers current traffic). No rules needed — URL-driven `/cdn-cgi/image/width=192,dpr=2,format=auto/...`. I then PR `srcset` DPR variants into `soci-post-li`/`soci-post-card` behind a server-config flag; expect another 30–50% off cold feed media bytes on 2x devices. (Polish not worth the Pro bump — it can't DPR-match and double-compresses our tuned thumbnails.)

**5. Read replicas: not yet.** Queries are 2–5 ms behind PostCache and hot-path indexes; the box does ~2,400 req/s on `/posts`. Tripwire (from RUM): logged-in TTFB p75 from any region > 2× anonymous p75 for a week. Then: Vultr AMS/SGP MariaDB replica (GTID, read_only), send me the host — I PR a `REPLICA_DSN` read path for the three read endpoints with a lag guard.

**6. RUM.** Web Analytics → enable for `non.io` with automatic injection (free, no cookies, zero code). Core Web Vitals by path/country within a day; this is also what validates items 1–4 and arms item 5's tripwire. Optional token addition: Account Analytics Read. If we later need SPA-transition timings no third-party RUM sees, the custom `PerformanceObserver` → `POST /rum` beacon is a small self-contained PR.

**7. Grab-bag:** $5 second-vantage VPS (Frankfurt/Singapore) with the harness pubkey if you want controlled non-US lanes; iter09's BBR/fq sysctls staged in `provision.sh` for when SSH is back; SPF/DKIM + a transactional email sender while you're in DNS (password resets currently ride a Gmail app password).

| # | You do | Send me | Unblocks |
|---|---|---|---|
| 0 | CF zone, nameservers, proxied A, Full (strict) + Origin CA, scoped token | token, zone id, cert | everything |
| 1 | two Cache Rules (or I do via token) | — | edge HTML |
| 2 | nothing (my PR + rule) | — | edge anon API |
| 3 | h3/0-RTT/WebSockets ON, Rocket Loader OFF | — | anycast TLS/h3 |
| 4 | enable Transformations | "enabled" | DPR srcset PR |
| 5 | nothing until RUM trips | — | replicas |
| 6 | enable Web Analytics | (optional) analytics read | real numbers |
| 7 | optional second VPS, SSH key | user@ip, key | vantage 2, VPS tuning |

## Verification done here

- `go test ./...` (backend, incl. new WS tests), frontend `npm test` 18/18, all four CDN suites — green.
- Browser probes above, all green, including cold-click-before-warmup and back-nav.
- Live two-user WS badge flow in a real browser: 0 polls while connected.
- Full measurement A/B on the seeded stack (tables above; method + numbers appended to `SPEED_LAB.md`).

Couldn't SSH to the VPS (no key on this machine), so measurements are local-stack A/Bs with the lab's own throttled lanes rather than live-box WAN numbers; the deploy-and-remeasure plan for the box is in the playbook.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50b57b95-3fb1-4fc8-b678-59ab37fe663d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b57b95-3fb1-4fc8-b678-59ab37fe663d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

