### PR TITLE
Deprecate HEIC/HEIF: ingest and serve webp only

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,3 +1,40 @@
+## 2026-08-25 — HEIC/HEIF deprecated: webp in, webp out (branch `cursor/deprecate-heic-serve-webp-only-ed87`)
+
+Nonio now ingests and serves webp only. HEIC/HEIF uploads are transcoded on the
+way in; nothing writes or serves `.heic` any more.
+
+- **soci-image-cdn ingest:** `encode.Image` sniffs the upload's own bytes
+  (`isHEIF` reads the ISO-BMFF ftyp box, covering the `heix`/`hevc`/`mif1`/…
+  brands `filetype` misses) and runs HEIC/HEIF through the *same* convert
+  pipeline as any other photo — `-resize 192x144^` thumbnail plus the full
+  webp, no extra encoder flags. The three near-identical per-format branches
+  collapsed into `encodeCommands`, which now returns commands and can be
+  asserted on; convert's stderr is folded into the returned error so a missing
+  imagemagick delegate stops being an opaque "exit status 1".
+- **soci-image-cdn + soci-avatar-cdn serving:** `webpOnly` wraps both file
+  servers and answers `.heic`/`.heif` with 410 + `text/plain`, so leftovers from
+  the old dual-encode pipeline can never come back as `image/heic`. Cache TTLs
+  unchanged (images 1 day, avatars 5 min — names aren't content-hashed).
+- **soci-avatar-cdn encode:** avatar + banner `convert` calls no longer write
+  the `.heic` copies (which, incidentally, fail outright on ImageMagick builds
+  where HEIC is read-only).
+- **Upload routing:** content-type parsing moved to `util.MediaCategory`,
+  shared by `/upload` and `/fetch-og-image`. An upload that is neither image nor
+  video now answers 400 instead of panicking on a nil regexp match or returning
+  200 having encoded nothing.
+- **Frontend:** `<source class="heic">` removed from `soci-post-li`,
+  `soci-post-card`, `soci-user` and `soci-avatar-uploader` (those requests were
+  404s already, since image-cdn never produced heic).
+- **Tests:** `soci-image-cdn/encode` covers brand sniffing, "heic gets the same
+  settings as jpeg", the heic→webp ingest via an exec seam, plus a real
+  end-to-end heic→webp encode that skips unless `convert`/`heif-enc` are
+  installed; `serve_test.go` in both CDNs covers the 410; frontend
+  `media-formats.test.js` guards against a heic link creeping back.
+
+Tradeoff: iOS uploads now cost one HEVC decode on the upload path (CPU at
+ingest) in exchange for one stored format, one URL per image, and no HEIC
+decode on any client.
+
 ## 2026-08-24 — VPS speed lab: live deploy + measured perf loop (branch `cursor/speed-vps-loop-27f0`)
 
 Deployed the monorepo to a live 1-vCPU/1 GB Vultr box (108.61.219.46) with a

--- a/soci-avatar-cdn/.gitignore
+++ b/soci-avatar-cdn/.gitignore
@@ -1,6 +1,5 @@
 soci-avatar-cdn
 files/images/*.webp
-files/images/*.heic
 files/temp-images/*
 !files/temp-images/readme.md
 files/videos/*.webm
@@ -8,5 +7,4 @@ files/videos/*.mp4
 files/temp-videos/*
 !files/temp-videos/readme.md
 files/thumbnails/*.webp
-files/thumbnails/*.heic
 config.json

--- a/soci-avatar-cdn/encode/image.go
+++ b/soci-avatar-cdn/encode/image.go
@@ -88,8 +88,6 @@ func Image(file multipart.File, user string, xOffset int, yOffset int, size int)
 	// since this is an image we'll use magick to encode it
 	cmd := exec.Command("convert", tempFile.Name(),
 		"(", "+clone", "-resize", "96x96^", "-write", fmt.Sprintf("files/thumbnails/%v.webp", name), "+delete", ")",
-		"(", "+clone", "-resize", "96x96^", "-write", fmt.Sprintf("files/thumbnails/%v.heic", name), "+delete", ")",
-		"(", "+clone", "-resize", "512x512>", "-write", fmt.Sprintf("files/images/%v.heic", name), "+delete", ")",
 		"-resize", "512x512>", fmt.Sprintf("files/images/%v.webp", name))
 	cmd.Dir = workingDir
 	var output bytes.Buffer
@@ -173,8 +171,6 @@ func Banner(file multipart.File, user string, xOffset int, yOffset int, cropWidt
 	// Resize to banner dimensions: 800x180 full, 160x36 thumbnail
 	cmd := exec.Command("convert", tempFile.Name(),
 		"(", "+clone", "-resize", "160x36!", "-write", fmt.Sprintf("files/thumbnails/%v.webp", name), "+delete", ")",
-		"(", "+clone", "-resize", "160x36!", "-write", fmt.Sprintf("files/thumbnails/%v.heic", name), "+delete", ")",
-		"(", "+clone", "-resize", "800x180!", "-write", fmt.Sprintf("files/images/%v.heic", name), "+delete", ")",
 		"-resize", "800x180!", fmt.Sprintf("files/images/%v.webp", name))
 	cmd.Dir = workingDir
 	var output bytes.Buffer

--- a/soci-avatar-cdn/main.go
+++ b/soci-avatar-cdn/main.go
@@ -10,9 +10,9 @@ import (
 
 func setupRoutes(settings *config.Config) {
 	avatarCache := "public, max-age=300"
-	http.Handle("/thumbnail/", http.StripPrefix("/thumbnail/", cacheControl(avatarCache, http.FileServer(http.Dir("./files/thumbnails")))))
+	http.Handle("/thumbnail/", http.StripPrefix("/thumbnail/", webpOnly(cacheControl(avatarCache, http.FileServer(http.Dir("./files/thumbnails"))))))
 	http.HandleFunc("/upload", route.UploadFile)
-	http.Handle("/", cacheControl(avatarCache, http.FileServer(http.Dir("./files/images"))))
+	http.Handle("/", webpOnly(cacheControl(avatarCache, http.FileServer(http.Dir("./files/images")))))
 
 	port := os.Getenv("APP_PORT")
 	if port == "" {

--- a/soci-avatar-cdn/serve.go
+++ b/soci-avatar-cdn/serve.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+	"path"
+	"strings"
+)
+
+// webpOnly refuses HEIC/HEIF requests instead of letting the file server hand
+// back an image/heic body. Avatars are encoded as webp only now, so a .heic on
+// disk is a leftover from the old dual-encode pipeline and is gone for good.
+func webpOnly(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch strings.ToLower(path.Ext(r.URL.Path)) {
+		case ".heic", ".heif":
+			http.Error(w, "HEIC is no longer served, request the .webp instead", http.StatusGone)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/soci-avatar-cdn/serve_test.go
+++ b/soci-avatar-cdn/serve_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWebpOnlyRefusesLeftoverHEICAvatars(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "someuser.webp"), []byte("webp bytes"), 0644)
+	os.WriteFile(filepath.Join(dir, "someuser.heic"), []byte("heic bytes"), 0644)
+	server := webpOnly(cacheControl("public, max-age=300", http.FileServer(http.Dir(dir))))
+
+	rec := httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest("GET", "/someuser.webp", nil))
+	if rec.Code != 200 {
+		t.Fatalf("Avatars should still be served as webp, got %v", rec.Code)
+	}
+
+	for _, path := range []string{"/someuser.heic", "/someuser.HEIC", "/someuser.heif"} {
+		rec = httptest.NewRecorder()
+		server.ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+		if rec.Code != http.StatusGone {
+			t.Errorf("%v should answer 410, got %v", path, rec.Code)
+		}
+		if contentType := rec.Header().Get("Content-Type"); strings.HasPrefix(contentType, "image/") {
+			t.Errorf("%v should not answer with an image content type, got %q", path, contentType)
+		}
+	}
+}

--- a/soci-backend/docs/api/posts.pug
+++ b/soci-backend/docs/api/posts.pug
@@ -175,7 +175,7 @@ block content
         files: (binary)
 
       h5 Response
-      p Responds with the temporary name of the image after encoding. This can be accessed via https://image.non.io/${tempName}.webp or via other file extensions. 
+      p Responds with the temporary name of the image after encoding. Uploads are transcoded to webp - including HEIC/HEIF from iOS - so the only extension served is .webp, at https://image.non.io/${tempName}.webp. Requests for .heic or .heif answer 410.
       :code(javascript)
         4e4b2709-e82e-415d-ae6d-5e9f1efaaae8
 
@@ -208,7 +208,7 @@ block content
         }
 
       h5 Response
-      p Responds with the temporary name of the image after encoding. This can be accessed via https://image.non.io/${tempName}.webp or via other file extensions. 
+      p Responds with the created post. Its image is served as webp only, at https://image.non.io/${url}.webp.
       :code(javascript)
         {
           "ID": 28,

--- a/soci-frontend/components/soci-avatar-uploader.js
+++ b/soci-frontend/components/soci-avatar-uploader.js
@@ -320,18 +320,8 @@ export default class SociAvatarUploader extends SociComponent {
   }
 
   _loadCurrentAvatar(){
-    const formats = [
-      {tag: 'source', extension: 'webp'},
-      {tag: 'source', extension: 'heic'},
-      {tag: 'img', extension: 'webp'},
-    ]
-    const ts = Date.now()
-    const html = formats.map(format=>{
-      const attr = format.tag === 'source' ? 'srcset' : 'src'
-      return `<${format.tag} ${attr}="${config.AVATAR_HOST}/${this._avatarPath}.${format.extension}?${ts}">`
-    })
-    this.select('picture').innerHTML = html.join('')
-    this._currentAvatarUrl = `${config.AVATAR_HOST}/${this._avatarPath}.webp?${ts}`
+    this._currentAvatarUrl = `${config.AVATAR_HOST}/${this._avatarPath}.webp?${Date.now()}`
+    this.select('picture').innerHTML = `<img src="${this._currentAvatarUrl}">`
     this.select('#preview').src = this._currentAvatarUrl
   }
 

--- a/soci-frontend/components/soci-post-card.js
+++ b/soci-frontend/components/soci-post-card.js
@@ -190,8 +190,6 @@ export default class SociPostCard extends SociPostLi {
       <div id="media">
         <soci-link id="media-link" href="${postPath}">
           <picture>
-            <source class="heic">
-            <source class="webp">
             <img @load=_onImageLoad />
           </picture>
         </soci-link>
@@ -256,9 +254,6 @@ export default class SociPostCard extends SociPostLi {
     
     img.src = `${host}/${this.url}.webp`
     img.onerror = () => this.classList.add('no-image')
-    
-    container.querySelector('.heic').src = `${host}/${this.url}.heic`
-    container.querySelector('.webp').src = `${host}/${this.url}.webp`
   }
 
   loadContent(type) {

--- a/soci-frontend/components/soci-post-li.js
+++ b/soci-frontend/components/soci-post-li.js
@@ -326,15 +326,11 @@ export default class SociPostLi extends SociComponent {
     return `
     <slot name="thumbnail">
       <picture id="thumbnail">
-        <source class="heic">
-        <source class="webp">
         <img @click=expand />
       </picture>
     </slot>
     <div id="preview">
       <picture>
-        <source class="heic">
-        <source class="webp">
         <img @click=expand />
       </picture>
       <content></content>
@@ -514,8 +510,6 @@ export default class SociPostLi extends SociComponent {
     img.onerror = () => {
       this.classList.toggle('no-image', true)
     }
-    container.querySelector('.heic').src = `${host}/${this.url}.heic`
-    container.querySelector('.webp').src = `${host}/${this.url}.webp`
   }
 
   loadContent(type) {

--- a/soci-frontend/components/soci-user.js
+++ b/soci-frontend/components/soci-user.js
@@ -157,9 +157,9 @@ export default class SociUser extends SociComponent {
     if(!path) return ''
     let cacheBuster = force ? `?${Date.now()}` : ''
     let basePath = this.getAttribute('size') == 'large' ? path : `thumbnail/${path}`
-    let formats = ['webp', 'heic'].map(format => `<source srcset="${config.AVATAR_HOST}/${basePath}.${format}${cacheBuster}" />`).join('')
+    let webp = `<source srcset="${config.AVATAR_HOST}/${basePath}.webp${cacheBuster}" />`
     // Avatars are never the LCP element; lazy keeps offscreen feed rows from
     // fetching a hundred of them during initial load.
-    return (path == 'Anonymous coward' ? '' : formats) + `<img loading="lazy" decoding="async" src="${config.AVATAR_HOST}/thumbnail/default.png"/>`
+    return (path == 'Anonymous coward' ? '' : webp) + `<img loading="lazy" decoding="async" src="${config.AVATAR_HOST}/thumbnail/default.png"/>`
   }
 }

--- a/soci-frontend/test/media-formats.test.js
+++ b/soci-frontend/test/media-formats.test.js
@@ -1,0 +1,21 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+
+// The CDNs ingest and serve webp only - a .heic source in a <picture> is a
+// guaranteed 410 from image.non.io and avatar.non.io.
+test('nothing links HEIC images', () => {
+  const offenders = []
+  for (const dir of ['components', 'pages', 'lib']) {
+    for (const file of fs.readdirSync(path.join(root, dir), { recursive: true })) {
+      if (!/\.(js|pug|html|css)$/.test(file)) continue
+      const source = fs.readFileSync(path.join(root, dir, file), 'utf8')
+      if (/heic|heif/i.test(source)) offenders.push(`${dir}/${file}`)
+    }
+  }
+  assert.deepEqual(offenders, [])
+})

--- a/soci-image-cdn/.gitignore
+++ b/soci-image-cdn/.gitignore
@@ -1,6 +1,5 @@
 soci-image-cdn
 files/images/*.webp
-files/images/*.heic
 files/temp-images/*
 !files/temp-images/readme.md
 files/videos/*.webm
@@ -8,5 +7,4 @@ files/videos/*.mp4
 files/temp-videos/*
 !files/temp-videos/readme.md
 files/thumbnails/*.webp
-files/thumbnails/*.heic
 config.json

--- a/soci-image-cdn/encode/image.go
+++ b/soci-image-cdn/encode/image.go
@@ -2,15 +2,87 @@ package encode
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/h2non/filetype"
 )
+
+// execCommand is a seam so the encoding pipeline can be asserted on without
+// imagemagick present.
+var execCommand = exec.Command
+
+// heifBrands are the ISO-BMFF ftyp brands HEIC/HEIF stills ship with. filetype
+// only knows "heic", so an iPhone export carrying any of the others would be
+// turned away before we get the chance to transcode it.
+var heifBrands = map[string]bool{
+	"heic": true, "heix": true, "heim": true, "heis": true, "heif": true,
+	"hevc": true, "hevx": true, "hevm": true, "hevs": true,
+	"mif1": true, "msf1": true,
+}
+
+// isHEIF reports whether buf starts with a HEIC/HEIF ftyp box, checking the
+// major brand and then the compatible brands that follow the minor version.
+func isHEIF(buf []byte) bool {
+	if len(buf) < 12 || string(buf[4:8]) != "ftyp" {
+		return false
+	}
+	if heifBrands[string(buf[8:12])] {
+		return true
+	}
+	box := int(binary.BigEndian.Uint32(buf[0:4]))
+	for i := 16; i+4 <= len(buf) && i+4 <= box; i += 4 {
+		if heifBrands[string(buf[i:i+4])] {
+			return true
+		}
+	}
+	return false
+}
+
+// imageMIME sniffs the upload's own bytes rather than trusting the declared
+// content type, and reports HEIC/HEIF as image/heif so it reaches the encoder.
+func imageMIME(buf []byte) (string, error) {
+	if isHEIF(buf) {
+		return "image/heif", nil
+	}
+	kind, err := filetype.Match(buf)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(kind.MIME.Value, "image/") {
+		return "", errors.New("file type not supported")
+	}
+	return kind.MIME.Value, nil
+}
+
+// encodeCommands returns the commands that turn src into the image and
+// thumbnail for url. Every output is a webp: HEIC/HEIF is transcoded with the
+// same settings as any other photo so nothing but webp reaches the disk.
+func encodeCommands(mime, src, url string) [][]string {
+	image := fmt.Sprintf("files/images/%v.webp", url)
+	thumbnail := fmt.Sprintf("files/thumbnails/%v.webp", url)
+
+	switch mime {
+	case "image/gif":
+		// Gifs need a static thumbnail off the first frame, then gif2webp for
+		// the animation itself.
+		return [][]string{
+			{"convert", fmt.Sprintf("%v[0]", src), "-resize", "192x144^", thumbnail},
+			{"gif2webp", src, "-o", image},
+		}
+	case "image/png":
+		// Screenshots and line art keep their edges with lossless webp.
+		return [][]string{{"convert", src, "(", "+clone", "-resize", "192x144^", "-write", thumbnail, "+delete", ")", "-define", "webp:lossless=true", image}}
+	default:
+		return [][]string{{"convert", src, "(", "+clone", "-resize", "192x144^", "-write", thumbnail, "+delete", ")", image}}
+	}
+}
 
 // Image encodes the image into a webp and returns the path to it
 func Image(file io.Reader, url string) error {
@@ -30,77 +102,31 @@ func Image(file io.Reader, url string) error {
 	}
 	tempFile.Write(fileBytes)
 
-	if !filetype.IsImage(fileBytes) {
-		err = errors.New("file type not supported")
-		return err
-	}
-
-	// read the file header and check
-	kind, err := filetype.Match(fileBytes)
+	mime, err := imageMIME(fileBytes)
 	if err != nil {
 		fmt.Println(err)
 		return err
 	}
-	if kind.MIME.Value == "image/gif" {
-		// It's a gif, so we gotta create a static thumbnail first, then use ffmpeg to create an animated webp
-		cmd := exec.Command("convert", fmt.Sprintf("%v[0]", tempFile.Name()), "-resize", "192x144^", fmt.Sprintf("files/thumbnails/%v.webp", url))
-		workingDir, err := os.Getwd()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	for _, args := range encodeCommands(mime, tempFile.Name(), url) {
+		cmd := execCommand(args[0], args[1:]...)
 		cmd.Dir = workingDir
 		var output bytes.Buffer
 		cmd.Stderr = &output
-		err = cmd.Run()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-		cmd = exec.Command("gif2webp", tempFile.Name(), "-o", fmt.Sprintf("files/images/%v.webp", url))
-		cmd.Dir = workingDir
-		cmd.Stderr = &output
-		err = cmd.Run()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-	} else if kind.MIME.Value == "image/png" {
-		// It's a png image, so set the flags to be lossless
-		cmd := exec.Command("convert", tempFile.Name(), "(", "+clone", "-resize", "192x144^", "-write", fmt.Sprintf("files/thumbnails/%v.webp", url), "+delete", ")", "-define", "webp:lossless=true", fmt.Sprintf("files/images/%v.webp", url))
-		workingDir, err := os.Getwd()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-		cmd.Dir = workingDir
-		var output bytes.Buffer
-		cmd.Stderr = &output
-		err = cmd.Run()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-	} else {
-		// It's a normal image, just use imagemagick to convert it
-		cmd := exec.Command("convert", tempFile.Name(), "(", "+clone", "-resize", "192x144^", "-write", fmt.Sprintf("files/thumbnails/%v.webp", url), "+delete", ")", fmt.Sprintf("files/images/%v.webp", url))
-		workingDir, err := os.Getwd()
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-		cmd.Dir = workingDir
-		var output bytes.Buffer
-		cmd.Stderr = &output
-		err = cmd.Run()
-		if err != nil {
+		if err := cmd.Run(); err != nil {
+			// The stderr matters here: a missing imagemagick delegate for the
+			// uploaded format is otherwise an opaque "exit status 1".
+			err = fmt.Errorf("%v: %v: %v", args[0], err, strings.TrimSpace(output.String()))
 			fmt.Println(err)
 			return err
 		}
 	}
 
-	return err
+	return nil
 }

--- a/soci-image-cdn/encode/image_test.go
+++ b/soci-image-cdn/encode/image_test.go
@@ -1,0 +1,193 @@
+package encode
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// heicFile builds the ftyp box of a HEIC still: a box length, the "ftyp" tag,
+// a major brand, a minor version and any compatible brands.
+func heicFile(major string, compatible ...string) []byte {
+	body := []byte("ftyp" + major + "\x00\x00\x00\x00" + strings.Join(compatible, ""))
+	return append([]byte{0, 0, 0, byte(len(body) + 4)}, body...)
+}
+
+// workspace gives the encoder the files/ tree it writes into, in a temp dir.
+func workspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{"files/temp-images", "files/images", "files/thumbnails"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(previous) })
+	return dir
+}
+
+// recordCommands swaps the exec seam for one that records what would have run.
+func recordCommands(t *testing.T) *[][]string {
+	t.Helper()
+	var ran [][]string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		ran = append(ran, append([]string{name}, args...))
+		return exec.Command("true")
+	}
+	t.Cleanup(func() { execCommand = exec.Command })
+	return &ran
+}
+
+func TestIsHEIFRecognizesTheBrandsCamerasWrite(t *testing.T) {
+	heif := map[string][]byte{
+		"iPhone still":        heicFile("heic", "mif1", "heic"),
+		"burst still":         heicFile("heix", "mif1", "heix"),
+		"brandless container": heicFile("mif1", "mif1", "heic"),
+		"compatible only":     heicFile("isom", "mif1", "heic"),
+	}
+	for name, buf := range heif {
+		if !isHEIF(buf) {
+			t.Errorf("%v should be detected as HEIC/HEIF", name)
+		}
+	}
+
+	other := map[string][]byte{
+		"mp4":       heicFile("isom", "isom", "mp42"),
+		"jpeg":      {0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0},
+		"too short": []byte("ftyp"),
+		"text":      []byte("this is not an image at all"),
+	}
+	for name, buf := range other {
+		if isHEIF(buf) {
+			t.Errorf("%v should not be detected as HEIC/HEIF", name)
+		}
+	}
+}
+
+func TestImageMIMEReportsHEICAsHEIF(t *testing.T) {
+	mime, err := imageMIME(heicFile("heic", "mif1", "heic"))
+	if err != nil {
+		t.Fatalf("A HEIC upload should be accepted. Error: %v", err)
+	}
+	if mime != "image/heif" {
+		t.Errorf("Expected image/heif, got %q", mime)
+	}
+}
+
+func TestImageMIMERejectsNonImages(t *testing.T) {
+	if _, err := imageMIME([]byte("<html>not an image</html>")); err == nil {
+		t.Error("A non-image upload should be rejected")
+	}
+}
+
+func TestEncodeCommandsOnlyEverWritesWebp(t *testing.T) {
+	for _, mime := range []string{"image/heif", "image/jpeg", "image/png", "image/gif", "image/tiff"} {
+		for _, args := range encodeCommands(mime, "files/temp-images/image-1", "my-post") {
+			for _, arg := range args {
+				if strings.Contains(arg, ".heic") || strings.Contains(arg, ".heif") {
+					t.Errorf("%v encoding should not touch HEIC, got %v", mime, args)
+				}
+			}
+		}
+	}
+}
+
+func TestEncodeCommandsGivesHEICTheSameSettingsAsAnyOtherPhoto(t *testing.T) {
+	heic := encodeCommands("image/heif", "files/temp-images/image-1", "my-post")
+	jpeg := encodeCommands("image/jpeg", "files/temp-images/image-1", "my-post")
+	if !reflect.DeepEqual(heic, jpeg) {
+		t.Errorf("HEIC should reuse the existing photo settings.\n heic: %v\n jpeg: %v", heic, jpeg)
+	}
+}
+
+func TestImageTranscodesHEICUploadsToWebp(t *testing.T) {
+	workspace(t)
+	ran := recordCommands(t)
+
+	if err := Image(bytes.NewReader(heicFile("heic", "mif1", "heic")), "my-post"); err != nil {
+		t.Fatalf("A HEIC upload should encode. Error: %v", err)
+	}
+
+	if len(*ran) != 1 {
+		t.Fatalf("Expected a single convert, got %v", *ran)
+	}
+	command := strings.Join((*ran)[0], " ")
+	for _, want := range []string{"convert", "files/thumbnails/my-post.webp", "files/images/my-post.webp"} {
+		if !strings.Contains(command, want) {
+			t.Errorf("Expected %q in the encode command, got %v", want, command)
+		}
+	}
+	if strings.Contains(command, "heic") || strings.Contains(command, "heif") {
+		t.Errorf("The HEIC upload should leave nothing but webp behind, got %v", command)
+	}
+}
+
+func TestImageRejectsUploadsThatArentImages(t *testing.T) {
+	workspace(t)
+	ran := recordCommands(t)
+
+	if err := Image(strings.NewReader("nope"), "my-post"); err == nil {
+		t.Error("A non-image upload should be rejected")
+	}
+	if len(*ran) != 0 {
+		t.Errorf("Nothing should be encoded for a rejected upload, got %v", *ran)
+	}
+}
+
+// TestImageEncodesRealHEICWhenTheToolchainIsInstalled is the end to end check:
+// imagemagick reads the HEIC and hands back a webp image and thumbnail.
+func TestImageEncodesRealHEICWhenTheToolchainIsInstalled(t *testing.T) {
+	if _, err := exec.LookPath("convert"); err != nil {
+		t.Skip("imagemagick is not installed")
+	}
+	if _, err := exec.LookPath("heif-enc"); err != nil {
+		t.Skip("heif-enc is not installed, cannot build a HEIC fixture")
+	}
+	dir := workspace(t)
+
+	png := filepath.Join(dir, "fixture.png")
+	heic := filepath.Join(dir, "fixture.heic")
+	if out, err := exec.Command("convert", "-size", "320x240", "gradient:red-blue", png).CombinedOutput(); err != nil {
+		t.Skipf("could not build a png fixture: %v: %s", err, out)
+	}
+	if out, err := exec.Command("heif-enc", png, "-o", heic).CombinedOutput(); err != nil {
+		t.Skipf("could not build a HEIC fixture: %v: %s", err, out)
+	}
+
+	upload, err := os.Open(heic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upload.Close()
+
+	if err := Image(upload, "my-post"); err != nil {
+		t.Fatalf("A real HEIC upload should encode. Error: %v", err)
+	}
+
+	for _, written := range []string{"files/images/my-post.webp", "files/thumbnails/my-post.webp"} {
+		encoded, err := ioutil.ReadFile(filepath.Join(dir, written))
+		if err != nil {
+			t.Fatalf("Expected %v to exist. Error: %v", written, err)
+		}
+		if len(encoded) < 12 || string(encoded[0:4]) != "RIFF" || string(encoded[8:12]) != "WEBP" {
+			t.Errorf("%v should be a webp of %v bytes", written, len(encoded))
+		}
+	}
+	for _, forbidden := range []string{"files/images/my-post.heic", "files/thumbnails/my-post.heic"} {
+		if _, err := os.Stat(filepath.Join(dir, forbidden)); err == nil {
+			t.Errorf("%v should not be written any more", forbidden)
+		}
+	}
+}

--- a/soci-image-cdn/main.go
+++ b/soci-image-cdn/main.go
@@ -10,8 +10,8 @@ import (
 
 func setupRoutes(settings *config.Config) {
 	imageCache := "public, max-age=86400"
-	http.Handle("/", cacheControl(imageCache, http.FileServer(http.Dir("./files/images"))))
-	http.Handle("/thumbnail/", http.StripPrefix("/thumbnail/", cacheControl(imageCache, http.FileServer(http.Dir("./files/thumbnails")))))
+	http.Handle("/", webpOnly(cacheControl(imageCache, http.FileServer(http.Dir("./files/images")))))
+	http.Handle("/thumbnail/", http.StripPrefix("/thumbnail/", webpOnly(cacheControl(imageCache, http.FileServer(http.Dir("./files/thumbnails"))))))
 	http.HandleFunc("/upload", route.UploadFile)
 	http.HandleFunc("/fetch-og-image", route.FetchOGImage)
 	http.HandleFunc("/move", route.MoveFile)

--- a/soci-image-cdn/route/fetchOGImage.go
+++ b/soci-image-cdn/route/fetchOGImage.go
@@ -3,7 +3,6 @@ package route
 import (
 	"fmt"
 	"net/http"
-	"regexp"
 	"soci-image-cdn/encode"
 	"soci-image-cdn/util"
 
@@ -69,10 +68,7 @@ func FetchOGImage(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	re, _ := regexp.Compile("([a-zA-Z]+)/")
-	var mimeType = resp.Header["Content-Type"][0]
-
-	if re.FindStringSubmatch(mimeType)[1] != "image" {
+	if util.MediaCategory(resp.Header.Get("Content-Type")) != "image" {
 		util.SendError(w, "Thumbnail is not an image", 400)
 		return
 	}

--- a/soci-image-cdn/route/upload.go
+++ b/soci-image-cdn/route/upload.go
@@ -3,7 +3,6 @@ package route
 import (
 	"fmt"
 	"net/http"
-	"regexp"
 	"soci-image-cdn/encode"
 	"soci-image-cdn/util"
 
@@ -53,17 +52,19 @@ func UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	re, _ := regexp.Compile("([a-zA-Z]+)/")
-	var mimeType = handler.Header["Content-Type"][0]
+	mimeType := handler.Header.Get("Content-Type")
 
 	// If all is good, let's log what the hell is going on
-	fmt.Printf("%v is uploading a %v of size %v to %v\n", user, re.FindStringSubmatch(mimeType)[1], handler.Size, url)
+	fmt.Printf("%v is uploading a %v of size %v to %v\n", user, mimeType, handler.Size, url)
 
-	switch re.FindStringSubmatch(mimeType)[1] {
+	switch util.MediaCategory(mimeType) {
 	case "image":
 		err = encode.Image(file, url)
 	case "video":
 		err = encode.Video(file, url)
+	default:
+		util.SendError(w, fmt.Sprintf("Unsupported content type: %q", mimeType), 400)
+		return
 	}
 	if err != nil {
 		util.SendError(w, fmt.Sprintf("Error encoding the file: %v", err), 500)

--- a/soci-image-cdn/serve.go
+++ b/soci-image-cdn/serve.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+	"path"
+	"strings"
+)
+
+// webpOnly refuses HEIC/HEIF requests instead of letting the file server hand
+// back an image/heic body. The encoder only writes webp now, so a .heic on
+// disk is a leftover from the old dual-encode pipeline and is gone for good.
+func webpOnly(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch strings.ToLower(path.Ext(r.URL.Path)) {
+		case ".heic", ".heif":
+			http.Error(w, "HEIC is no longer served, request the .webp instead", http.StatusGone)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/soci-image-cdn/serve_test.go
+++ b/soci-image-cdn/serve_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// imageServer stands in for the file server main() wires up, with a leftover
+// heic from the old dual-encode pipeline sitting next to the webp.
+func imageServer(t *testing.T) http.Handler {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"my-post.webp", "my-post.heic"} {
+		if err := ioutil.WriteFile(filepath.Join(dir, name), []byte("bytes"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return webpOnly(cacheControl("public, max-age=86400", http.FileServer(http.Dir(dir))))
+}
+
+func TestWebpOnlyStillServesWebp(t *testing.T) {
+	rec := httptest.NewRecorder()
+	imageServer(t).ServeHTTP(rec, httptest.NewRequest("GET", "/my-post.webp", nil))
+
+	if rec.Code != 200 {
+		t.Fatalf("Expected 200, got %v", rec.Code)
+	}
+	if rec.Header().Get("Cache-Control") != "public, max-age=86400" {
+		t.Errorf("Images should keep their day long TTL, got %q", rec.Header().Get("Cache-Control"))
+	}
+}
+
+func TestWebpOnlyRefusesHEIC(t *testing.T) {
+	server := imageServer(t)
+
+	for _, path := range []string{"/my-post.heic", "/my-post.HEIC", "/my-post.heif", "/thumbnail/my-post.heic"} {
+		rec := httptest.NewRecorder()
+		server.ServeHTTP(rec, httptest.NewRequest("GET", path, nil))
+
+		if rec.Code != http.StatusGone {
+			t.Errorf("%v should answer 410, got %v", path, rec.Code)
+		}
+		if contentType := rec.Header().Get("Content-Type"); strings.HasPrefix(contentType, "image/") {
+			t.Errorf("%v should not answer with an image content type, got %q", path, contentType)
+		}
+		if rec.Body.String() == "bytes" {
+			t.Errorf("%v should not serve the leftover heic on disk", path)
+		}
+	}
+}

--- a/soci-image-cdn/util/mediaCategory.go
+++ b/soci-image-cdn/util/mediaCategory.go
@@ -1,0 +1,14 @@
+package util
+
+import "strings"
+
+// MediaCategory returns the top level type of a content type header - "image"
+// for "image/heic" - or an empty string when the header is missing or isn't a
+// media type at all.
+func MediaCategory(contentType string) string {
+	parts := strings.SplitN(contentType, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parts[0]))
+}

--- a/soci-image-cdn/util/mediaCategory_test.go
+++ b/soci-image-cdn/util/mediaCategory_test.go
@@ -1,0 +1,22 @@
+package util
+
+import "testing"
+
+func TestMediaCategory(t *testing.T) {
+	cases := map[string]string{
+		"image/heic":               "image",
+		"image/heif":               "image",
+		"IMAGE/JPEG":               "image",
+		"video/mp4":                "video",
+		"image/webp; charset=utf8": "image",
+		"application/octet-stream": "application",
+		"nonsense":                 "",
+		"":                         "",
+		"image/":                   "",
+	}
+	for contentType, want := range cases {
+		if got := MediaCategory(contentType); got != want {
+			t.Errorf("MediaCategory(%q) = %q, want %q", contentType, got, want)
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nonio now ingests and serves webp only. HEIC/HEIF uploads are transcoded on the way in, nothing writes a `.heic` any more, and the CDNs refuse to serve one.

## soci-image-cdn

**Ingest.** `encode.Image` sniffs the upload's own bytes instead of trusting the declared content type. `isHEIF` reads the ISO-BMFF `ftyp` box (major brand plus compatible brands), which covers the `heix` / `hevc` / `mif1` / `msf1` brands that `h2non/filetype` misses — those uploads used to be rejected outright as "file type not supported". HEIC/HEIF then runs through the **same** convert pipeline as any other photo: `-resize 192x144^` thumbnail plus the full webp, no extra encoder flags.

The three near-identical per-format branches collapsed into `encodeCommands(mime, src, url)`, which returns the commands to run so the settings can be asserted on directly. Convert's stderr is now folded into the returned error, so a missing imagemagick delegate stops being an opaque `exit status 1`.

**Serving.** `webpOnly` wraps the image and thumbnail file servers and answers `.heic` / `.heif` (any casing) with `410 Gone` and `text/plain`. There is no path left in the image CDN that can respond with an `image/heic` body — including the `.heic` files still sitting on disk from the old dual-encode pipeline. Cache-Control values are untouched (images stay at one day; names aren't content-hashed, so no immutable year).

**Upload routing.** Content-type parsing moved into `util.MediaCategory`, shared by `/upload` and `/fetch-og-image`. An upload that is neither image nor video now answers 400, instead of panicking on a nil regexp match (`Content-Type` absent) or answering 200 having encoded nothing.

## soci-avatar-cdn

The avatar and banner `convert` calls wrote a `.heic` next to every `.webp`; those clones are gone. Worth noting they fail outright on imagemagick builds where HEIC is read-only (`HEIC r--`), which is the common Linux packaging today. The same `webpOnly` 410 guards the avatar and thumbnail file servers so old `.heic` avatars can't be served either.

## soci-frontend

`<source class="heic">` removed from `soci-post-li`, `soci-post-card`, `soci-user` and `soci-avatar-uploader`. Those post requests were already 404s (image-cdn never produced heic), and avatars now have a webp-only origin. The `<picture>` wrappers the CSS targets stay; the `img` still carries the `onerror` no-image toggle, and `soci-avatar-uploader._loadCurrentAvatar` shrinks to a single `img` since its source and fallback were both the same webp.

## Filenames

Nothing in the DB or API changes: posts store the URL stem (`my-neato-image`), and the extension is appended at serve time. Keeping the stem and switching the extension to `.webp` is what already happens.

## Tests

- `soci-image-cdn/encode/image_test.go`: ftyp brand sniffing (iPhone stills, brand-only-in-compatible-brands, and negatives like mp4/jpeg/text); heic reported as `image/heif`; every command for every format writes only `.webp`; heic gets byte-identical settings to jpeg; heic→webp ingest asserted through an exec seam (no imagemagick needed); and an end-to-end test that builds a real HEIC with `heif-enc`, runs the encoder, and checks a `RIFF…WEBP` image plus thumbnail exist and no `.heic` was written. It skips when `convert`/`heif-enc` aren't installed. Verified passing locally with imagemagick + `libheif-plugin-x265`: 800x600 heic in, 800x600 webp plus 192x144 webp thumbnail out.
- `serve_test.go` in both CDNs: webp still serves with its usual TTL; `.heic` / `.HEIC` / `.heif` answer 410 with a non-image content type and never leak the on-disk bytes.
- `soci-image-cdn/util/mediaCategory_test.go` for the content-type parsing.
- `soci-frontend/test/media-formats.test.js` scans components/pages/lib so a heic link can't creep back.

`go test ./...` is green in both CDNs. Frontend `npm test` passes the new test; the six `server.test.js` failures reproduce on `master` in this sandbox (the spawned server doesn't come up here) and are unrelated.

## Tradeoff

Every iOS upload now pays an HEVC decode on the upload path — that is real CPU on the image CDN at ingest, and it needs imagemagick built with a HEIC *read* delegate (already required in practice, since HEIC uploads previously depended on it silently). In exchange: one stored format instead of two, one URL per image, roughly half the disk and no dual-encode step per upload, and no client ever asked to decode HEIC. The alternative — keep serving HEIC to Safari for its size win — costs a second encode of every image, two URLs to keep in sync, and a format only one browser family reads.

Do not merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e00d749-111a-4e94-b42f-fbd45f92ed87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e00d749-111a-4e94-b42f-fbd45f92ed87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

