### PR TITLE
Reserve the post media box before it loads, and make the login button clickable

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,3 +1,55 @@
+## 2026-08-25 — Two frontend bugs: post media CLS and the un-clickable login button (branch `cursor/fix-media-cls-and-login-click-dd0b`)
+
+**1. Post media resized itself mid-load.** `soci-image` pointed one `<img>` at
+the thumbnail and then re-pointed it at the full image, so the media area was
+sized by whichever bitmap happened to be decoded — the 192x144 thumbnail first,
+then the full image. `soci-video` had no poster at all and sized itself off the
+`<video>` default ratio until metadata arrived. Both snapped everything below
+them down the page.
+
+Fixed with a shared ratio-locked box, `soci-frontend/lib/media-frame.js`
+(`MEDIA_FRAME_CSS` + `lockRatio`). The frame takes its height from
+`aspect-ratio` alone and stacks its sources absolutely with `object-fit:
+contain`, so the thumbnail and the full media occupy the same box and the swap
+is invisible. Ratio sources, in order, never guessed: stored post
+`width`/`height` (now threaded from `soci-post` as attributes, so the box is
+final before a single byte is requested), else the thumbnail/poster's intrinsic
+ratio, else the full image or the video's metadata. Width is additionally capped
+by the ratio against the height bound, or a portrait post would reserve a box
+wider than its own media and letterbox itself.
+
+Also removed from `soci-post`: the `#image` block behind `soci-image`, which
+carried `style="display: none"` inline and so could never show, but did
+duplicate both CDN requests; its dead `_zoomImage` handler (`this.select()`
+with no selector); and the CSS that only styled it. Feed tiles
+(`soci-post-li` 96x72, `soci-post-card`) are deliberately untouched.
+
+**2. The login submit button could not be left-clicked, though Enter worked.**
+Not an overlay or a `disabled` state: `soci-button` sets `float: right` on its
+own `:host`, and `.modal-form` had no clearfix, so the full-width login button
+left the form's flow and `.modal-footer` — a later sibling — painted over it.
+`document.elementFromPoint` at the button's own centre returned
+`soci-link#create-account`. Enter never went near the button; it is handled by a
+`keydown` listener on the modal. Fixed in `soci.css` by un-floating
+`soci-button` inside `.modal-form` and making the form a `flow-root`.
+
+Two further login problems found while confirming the cause. Login ran the
+40-bit entropy gate meant for choosing a password, so a weak-but-correct
+existing password failed `reportValidity()` — `soci-password` now takes
+`no-entropy` (applied to login, and to the "old password" field in admin
+settings, which had the same lockout); register keeps the gate and the meter.
+And the form value was only synced on `keydown`/`keyup`, so an autofilled
+password never reached the payload; it now syncs on `input`/`change` and in
+`checkValidity`, the pre-submit hook. Also dropped a leftover debug rule that
+painted a red 10x10 square inside the field on focus.
+
+**Tests:** `soci-frontend/test/browser.test.js`, 17 cases driving real Chrome
+via `puppeteer-core` (devDependency; the suite self-skips when no Chrome is
+present, so `npm test` still runs anywhere). It fixtures the CDNs by request
+interception with generated PNGs, holding the full image back to prove the
+thumbnail is on screen alone, and asserts the reserved box is identical at every
+stage. 11 of the 17 fail against the pre-fix code. Frontend `npm test` 29/29.
+
 ## 2026-08-24 — VPS speed lab: live deploy + measured perf loop (branch `cursor/speed-vps-loop-27f0`)
 
 Deployed the monorepo to a live 1-vCPU/1 GB Vultr box (108.61.219.46) with a

--- a/soci-frontend/components/modals/soci-login-modal.js
+++ b/soci-frontend/components/modals/soci-login-modal.js
@@ -5,7 +5,7 @@ class SociLoginModal extends HTMLElement {
     this.innerHTML = `
       <form class="modal-form">
         <input type="email" name="email" placeholder="Email address" autocomplete="email">
-        <soci-password name="password"></soci-password>
+        <soci-password no-entropy name="password"></soci-password>
         <soci-button async id="login-btn">login</soci-button>
       </form>
       <div class="modal-footer">

--- a/soci-frontend/components/soci-image.js
+++ b/soci-frontend/components/soci-image.js
@@ -1,5 +1,6 @@
 import SociComponent from './soci-component.js'
 import config from '../config.js'
+import { MEDIA_FRAME_CSS, lockRatio } from '../lib/media-frame.js'
 
 export default class SociImageViewer extends SociComponent {
   constructor() {
@@ -7,9 +8,28 @@ export default class SociImageViewer extends SociComponent {
   }
 
   css(){ return `
-    :host { width: 100%; display: block; overflow: auto; position: relative; }
+    :host {
+      --media-max-width: min(var(--media-width, 100%), 100%);
+      --media-max-height: min(calc(100vh - 100px), var(--media-height, calc(100vh - 100px)));
+      width: 100%;
+      display: block;
+      overflow: auto;
+      position: relative;
+    }
+    ${MEDIA_FRAME_CSS}
+    #frame {
+      z-index: 2;
+    }
     :host([zoomable]) #image { cursor: zoom-in; }
-    :host([zoomed]) #image { cursor: zoom-out; max-height: var(--media-height); max-width: var(--media-width); }
+    :host([zoomed]) #frame {
+      /* Zooming means "paint at 1:1 and let the host scroll", so the bounds the
+         frame is normally capped by have to come off. */
+      width: var(--natural-width);
+      max-width: none;
+      max-height: none;
+
+      #image { cursor: zoom-out; }
+    }
     ::-webkit-scrollbar { width: 14px; }
     ::-webkit-scrollbar-track { background: var(--bg-bold); }
     /* this is a bad hack to get alpha transparency on the scroll bars */
@@ -18,14 +38,6 @@ export default class SociImageViewer extends SociComponent {
       border-radius: 7px;
       border: 3px solid var(--bg-bold);
       &:hover { background: linear-gradient(90deg, var(--text-secondary-hover) -1500px, transparent 1000px); }
-    }
-    #image {
-      max-width: min(var(--media-width), 100%);
-      margin: 0 auto;
-      max-height: min(calc(100vh - 100px), var(--media-height));
-      display: block;
-      position: relative;
-      z-index: 2;
     }
     img.bg {
       position: absolute;
@@ -42,21 +54,25 @@ export default class SociImageViewer extends SociComponent {
   `}
 
   html(){ return `
-    <img id="image" @click=_toggleZoom />
+    <div id="frame">
+      <img id="thumb" />
+      <img id="image" @click=_toggleZoom />
+    </div>
     <img class="bg"/>
   `}
 
   static get observedAttributes() {
-    return ['url']
+    return ['url', 'width', 'height']
   }
 
   attributeChangedCallback(name, oldValue, newValue){
     if(name == 'url') this.url = newValue
+    else lockRatio(this, this.getAttribute('width'), this.getAttribute('height'))
   }
 
   connectedCallback(){
     this._checkZoomable = this._checkZoomable.bind(this)
-    this._image = this.select('#image')
+    this._frame = this.select('#frame')
     this._resizeObserver = new ResizeObserver(this._checkZoomable)
     this._resizeObserver.observe(this)
   }
@@ -66,7 +82,7 @@ export default class SociImageViewer extends SociComponent {
   }
 
   _checkZoomable(){
-    if(this.naturalWidth > this._image.offsetWidth || this.naturalHeight > this.offsetHeight){
+    if(this.naturalWidth > this._frame.offsetWidth || this.naturalHeight > this._frame.offsetHeight){
       this.toggleAttribute('zoomable', true)
     }
     else {
@@ -88,17 +104,32 @@ export default class SociImageViewer extends SociComponent {
       this.setAttribute('url', val)
       return
     }
+    let thumb = this.select('#thumb')
     let image = this.select('#image')
     let thumbUrl = `${config.THUMBNAIL_HOST}/${this.url}.webp`
-    image.src = thumbUrl
-    this.select('img.bg').src = thumbUrl
-    setTimeout(()=>{
-      image.onload = () => {
-        this.naturalWidth = image.naturalWidth
-        this.naturalHeight = image.naturalHeight
-        this._checkZoomable()
-      }
-      image.src = `${config.IMAGE_HOST}/${this.url}.webp`
-    },1)
+
+    // Posts predating stored dimensions have to be measured. The thumbnail is
+    // resized on the ratio it came in on, so it can stand in for the full image
+    // and it lands first by an order of magnitude.
+    let ratioIsKnown = lockRatio(this, this.getAttribute('width'), this.getAttribute('height'))
+    if(!ratioIsKnown)
+      thumb.onload = () => lockRatio(this, thumb.naturalWidth, thumb.naturalHeight)
+
+    image.onload = () => {
+      this.naturalWidth = image.naturalWidth
+      this.naturalHeight = image.naturalHeight
+      this.style.setProperty('--natural-width', `${image.naturalWidth}px`)
+      // Only a last resort, for when the thumbnail is missing too. Re-locking a
+      // box that is already reserved is the shift this component exists to
+      // avoid, even when the full image disagrees by a fraction of a pixel.
+      if(!this.hasAttribute('ratio'))
+        lockRatio(this, image.naturalWidth, image.naturalHeight)
+      this._checkZoomable()
+    }
+
+    thumb.src = this.select('img.bg').src = thumbUrl
+    // #image sits above #thumb in the frame and paints nothing until it decodes,
+    // so the two can load in parallel and the handoff needs no cross-fade.
+    image.src = `${config.IMAGE_HOST}/${this.url}.webp`
   }
 }

--- a/soci-frontend/components/soci-password.js
+++ b/soci-frontend/components/soci-password.js
@@ -1,5 +1,8 @@
 import SociComponent from './soci-component.js'
 
+const ENTROPY_REQUIREMENT = 40
+const WEAK_MESSAGE = 'Not strong enough. Add complexity until the circle fills.'
+
 export default class SociPassword extends SociComponent {
 
   static get formAssociated() {
@@ -37,16 +40,14 @@ export default class SociPassword extends SociComponent {
       outline: none;
     }
 
-    :host(:focus):after{
-      content: '';
-      width: 10px;
-      height: 10px;
-      display: block;
-      background: red;
-    }
-
     :host(:focus-within) svg {
       display: block;
+    }
+
+    /* Nothing to meter when the field is only being matched against a password
+       that already exists. */
+    :host([no-entropy]) svg {
+      display: none;
     }
 
     path { 
@@ -76,15 +77,18 @@ export default class SociPassword extends SociComponent {
   `}
 
   connectedCallback() {
-    this._internals.setValidity({customError: true}, 'Not strong enough. Add complexity until the circle fills.')
+    if(!this.hasAttribute('no-entropy'))
+      this._internals.setValidity({customError: true}, WEAK_MESSAGE)
     this.innerHTML = ''
     this.field = document.createElement('input')
     this.field.setAttribute('type','password')
     this.field.setAttribute('placeholder', this.getAttribute('placeholder') || 'Password')
     this.field.setAttribute('autocomplete', 'current-password')
     this.field.setAttribute('name', this.getAttribute('name') || 'password')
-    this.field.addEventListener('keydown', this._onKeyDown.bind(this))
-    this.field.addEventListener('keyup', this._onKeyDown.bind(this))
+    // input covers typing, paste, undo and autofill alike; keydown/keyup could
+    // not see a value the browser filled in without a keystroke.
+    this.field.addEventListener('input', this._onChange.bind(this))
+    this.field.addEventListener('change', this._onChange.bind(this))
     this.field.addEventListener('focus', this._onFocus.bind(this))
     this.field.addEventListener('blur', this._onBlur.bind(this))
     this.addEventListener('focus', this._onFocus)
@@ -126,15 +130,8 @@ export default class SociPassword extends SociComponent {
     this.setAttribute('tabindex', 0)
   }
 
-  _onChange(e) {
-    this._internals.setFormValue(this.value)
-  }
-
-  _onKeyDown() {
-    setTimeout(()=>{
-      this.checkValidity()
-      this._internals.setFormValue(this.value)
-    }, 1)
+  _onChange() {
+    this.checkValidity()
   }
 
   _updateValidity(message) {
@@ -155,7 +152,10 @@ export default class SociPassword extends SociComponent {
   }
 
   checkEntropy(){
-    const ENTROPY_REQUIREMENT = 40
+    // Strength is a property of a password being chosen. Checking it when the
+    // user is proving they know an existing one just locks them out of their
+    // own account, so login opts out.
+    if(this.hasAttribute('no-entropy')) return true
     let value = this.value
     let charsets = {
       numbers: false,
@@ -197,8 +197,11 @@ export default class SociPassword extends SociComponent {
   //checkValidity() { return this._internals.checkValidity() }
   reportValidity() {return this._internals.reportValidity() }
   checkValidity(){
+    // Callers reach for this immediately before reading the form, so it is also
+    // the last chance to publish a value the browser filled in silently.
+    this._internals.setFormValue(this.value)
     if(!this.checkEntropy()){
-      this._updateValidity('Not strong enough. Add complexity until the circle fills.')
+      this._updateValidity(WEAK_MESSAGE)
     }
     else if(!this.checkMatch()){
       this.closest('form')?.querySelector(`soci-password[name="${this.getAttribute('match')}"]`)?._updateValidity("Passwords do not match.")

--- a/soci-frontend/components/soci-post.js
+++ b/soci-frontend/components/soci-post.js
@@ -43,36 +43,6 @@ export default class SociPost extends SociComponent {
         --media-width: 100%;
       }
 
-      .media video,
-      .media img {
-        width: 100%;
-        max-width: var(--media-width);
-        max-height: min(calc(100vh - 100px), var(--media-height));
-        object-fit: contain;
-        position: relative;
-        z-index: 10;
-        display: block;
-        margin: 0 auto;
-      }
-
-      .media img {
-        max-width: var(--media-width);
-        max-height: var(--media-height);
-      }
-
-      .media img.bg {
-        position: inherit;
-        z-index: 9;
-        left: 0;
-        object-fit: cover;
-        transform: scale(1.1);
-        filter: blur(20px) brightness(0.8) saturate(0.8);
-        margin-bottom: 0;
-        position: absolute;
-        top: 0;
-        max-width: 100%;
-      }
-
       .media {
         opacity: 0;
       }
@@ -81,10 +51,6 @@ export default class SociPost extends SociComponent {
         opacity: 1;
         transition: opacity 0.3s var(--soci-ease-out);
         position: relative;
-      }
-
-      :host([type="image"]) #image {
-        display: block;
       }
 
       :host([type="video"]) #video {
@@ -339,6 +305,9 @@ export default class SociPost extends SociComponent {
 
   loadPost(url) {
     this.toggleAttribute('loaded', false)
+    // Back-nav reuses this element, and the previous post's dimensions would
+    // otherwise reserve the wrong box for a post that has none of its own.
+    this._width = this._height = 0
     this.getData(this._postApiPath(url)).then(post => {
       if(post.error) {
         this.select('#details-container').innerHTML = `<div id="error">${post.error}</div>`
@@ -367,12 +336,12 @@ export default class SociPost extends SociComponent {
             if(post[key] != '') this.select('#external-link').setAttribute('href', post[key])
             break
           case 'width':
-            if(parseInt(post[key]) != 0) 
-              this.select('#media-container').style.setProperty('--media-width', post[key] + 'px')
-            break
           case 'height':
-            if(parseInt(post[key]) != 0) 
-              this.select('#media-container').style.setProperty('--media-height', post[key] + 'px')
+            // Kept for loadContent, which reserves the media box from these
+            // before either the thumbnail or the full media is requested.
+            this['_' + key] = parseInt(post[key]) || 0
+            if(this['_' + key])
+              this.select('#media-container').style.setProperty(`--media-${key}`, post[key] + 'px')
             break
           case 'title':
             this.setAttribute('post-title', post[key])
@@ -478,7 +447,7 @@ export default class SociPost extends SociComponent {
           this.select('#media-container').innerHTML = ''
           this.select('#media-container').innerHTML = `
             <div id="video" class="media">
-              <soci-video></soci-video>
+              <soci-video ${this._mediaSize()}></soci-video>
             </div>
           `
           this.select('soci-video').url = this.url
@@ -493,33 +462,14 @@ export default class SociPost extends SociComponent {
 
   setImage(){
     this.setMeta('image', `${config.IMAGE_HOST}/${this.url}.webp`)
-    this.select('#media-container').innerHTML = `
-      <soci-image url="${this.url}"></soci-image>
-      <div id="image" class="media" style="display: none">
-        <picture>
-          <source>
-          <source>
-          <img/>
-        </picture>
-        <picture>
-          <source>
-          <source>
-          <img class="bg" />
-        </picture>
-      </div>
-    `
-    this.select('#media-container #image').addEventListener('click', this._zoomImage)
-    let img = this.select('#image img')
-    img.src = `${config.THUMBNAIL_HOST}/${this.url}.webp`
-    img.onerror = () => {
-      console.log('image load error')
-    }
+    this.select('#media-container').innerHTML = `<soci-image ${this._mediaSize()} url="${this.url}"></soci-image>`
+  }
 
-    this.select('#image img.bg').src = `${config.THUMBNAIL_HOST}/${this.url}.webp`
-    setTimeout(()=>{
-      this.select('#image img').src = `${config.IMAGE_HOST}/${this.url}.webp`
-      this.select('#image source').srcset = `${config.IMAGE_HOST}/${this.url}.webp`
-    },1)
+  // Stored post dimensions, for whichever media component is about to mount.
+  // They let it reserve the right box up front; without them it has to wait and
+  // measure the thumbnail instead.
+  _mediaSize(){
+    return this._width && this._height ? `width="${this._width}" height="${this._height}"` : ''
   }
 
   setMeta(property, value){
@@ -559,10 +509,6 @@ export default class SociPost extends SociComponent {
   _postApiPath(urlOverride){
     const slug = urlOverride || this.url
     return this.community ? `/posts/@${this.community}/${slug}` : `/posts/${slug}`
-  }
-
-  _zoomImage(){
-    this.select()
   }
 
   _scoreChanged(e){

--- a/soci-frontend/components/soci-video.js
+++ b/soci-frontend/components/soci-video.js
@@ -1,5 +1,6 @@
 import SociComponent from './soci-component.js'
 import config from '../config.js'
+import { MEDIA_FRAME_CSS, lockRatio } from '../lib/media-frame.js'
 
 export default class SociVideoPlayer extends SociComponent {
   constructor() {
@@ -8,21 +9,23 @@ export default class SociVideoPlayer extends SociComponent {
 
   css(){ return `
     :host {
+      /* Unlike an image, a video is free to scale past its source resolution
+         here, so width is bounded by the container rather than by --media-width. */
+      --media-max-width: 100%;
+      --media-max-height: calc(100vh - 100px);
       display: block;
       width: 100%;
       position: relative;
       background: #000;
     }
-    video {
-      /*
-      max-width: min(var(--media-width), 100%);
-      max-height: min(calc(100vh - 100px), var(--media-height));
-      */
-
-      width: 100%;
-      max-height: calc(100vh - 100px);
-      margin: 0 auto;
-      display: block;
+    ${MEDIA_FRAME_CSS}
+    :host(:fullscreen) {
+      --media-max-height: 100vh;
+      /* The frame letterboxes itself against the screen ratio, so it needs
+         centering in the leftover space rather than sizing to fill it. */
+      display: flex;
+      align-items: center;
+      height: 100vh;
     }
     controls {
       display: flex;
@@ -133,11 +136,6 @@ export default class SociVideoPlayer extends SociComponent {
     .track-container[seeking] .thumb {
       transition: none;
     }
-    :host(:fullscreen) video {
-      max-width: 100vw;
-      max-height: 100vh;
-      width: 100%;
-    }
     soci-icon[glyph="exitfullscreen"],
     :host(:fullscreen) soci-icon[glyph="fullscreen"] {
       display: none;
@@ -202,7 +200,7 @@ export default class SociVideoPlayer extends SociComponent {
   `}
 
   html(){ return `
-    <div id="video-container">
+    <div id="frame">
       <video autoplay @play=_onplay @pause=_onpause></video>
     </div>
     <controls>
@@ -233,7 +231,7 @@ export default class SociVideoPlayer extends SociComponent {
   `}
 
   static get observedAttributes() {
-    return ['url', 'resolution']
+    return ['url', 'resolution', 'width', 'height']
   }
 
   connectedCallback(){
@@ -260,6 +258,10 @@ export default class SociVideoPlayer extends SociComponent {
     switch(name) {
       case 'url':
         this.url = newValue
+        break
+      case 'width':
+      case 'height':
+        lockRatio(this, this.getAttribute('width'), this.getAttribute('height'))
         break
     }
   }
@@ -428,7 +430,7 @@ export default class SociVideoPlayer extends SociComponent {
       newVideo.addEventListener('play', this._onplay)
       newVideo.addEventListener('pause', this._onpause)
       newVideo.volume = this.volume
-      this.select('#video-container').appendChild(newVideo)
+      this.select('#frame').appendChild(newVideo)
 
       let hotswap = ()=>{
         timestamp = this._video.currentTime
@@ -479,6 +481,24 @@ export default class SociVideoPlayer extends SociComponent {
       this.setAttribute('url', val)
       return
     }
+    // The poster fills the reserved frame while the first video frame is still
+    // in flight, and both are laid out by #frame rather than by their own
+    // intrinsic size, so it hands over without resizing the media area.
+    let poster = `${config.VIDEO_HOST}/thumbnail/${val}.webp`
+    let video = this.select('video')
+    video.poster = poster
+
+    // Posts predating stored dimensions have to be measured. The poster is
+    // resized on the ratio it came in on and lands before the video does; the
+    // video's own metadata is the authority, but only arrives later.
+    if(!lockRatio(this, this.getAttribute('width'), this.getAttribute('height'))){
+      let probe = new Image()
+      probe.onload = () => lockRatio(this, probe.naturalWidth, probe.naturalHeight)
+      probe.src = poster
+      video.addEventListener('loadedmetadata',
+        () => lockRatio(this, video.videoWidth, video.videoHeight), {once: true})
+    }
+
     setTimeout(()=>{
       let width = parseInt(getComputedStyle(this).getPropertyValue('--media-width').slice(0, -2))
       let height = parseInt(getComputedStyle(this).getPropertyValue('--media-height').slice(0, -2))

--- a/soci-frontend/lib/media-frame.js
+++ b/soci-frontend/lib/media-frame.js
@@ -1,0 +1,44 @@
+// A ratio-locked box for post media, shared by soci-image and soci-video.
+//
+// Post media always arrives in two passes (thumbnail then full image, poster
+// then video). Sizing the box from whichever bitmap happens to be decoded
+// resizes the media area mid-load, which shifts everything below it. The frame
+// instead takes its size from the aspect ratio alone, so both passes lay out
+// identically and the swap is invisible.
+//
+// Consumers set --media-max-width and --media-max-height on their host to
+// whatever bounds that surface wants, and stack their sources as children of
+// #frame.
+export const MEDIA_FRAME_CSS = `
+  #frame {
+    position: relative;
+    margin: 0 auto;
+    /* Height comes from the ratio, so the box is final before any bytes land.
+       Width is additionally capped by the ratio against the height bound,
+       otherwise a portrait ratio would reserve a box wider than the media and
+       letterbox it. Both stay unset until a real ratio is known -- guessing one
+       would trade a late shift for a wrong box. */
+    aspect-ratio: var(--media-ratio);
+    width: min(var(--media-max-width), calc(var(--media-ratio) * var(--media-max-height)));
+    max-height: var(--media-max-height);
+
+    > * {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+  }
+`
+
+// Lock the frame to width/height, ignoring the zeroes and nulls that stand in
+// for "unknown" in post data. Returns whether a ratio is now set, so callers can
+// tell a stored ratio from one that still has to be measured off a bitmap.
+export function lockRatio(host, width, height){
+  if(width > 0 && height > 0){
+    host.style.setProperty('--media-ratio', width / height)
+    host.toggleAttribute('ratio', true)
+  }
+  return host.hasAttribute('ratio')
+}

--- a/soci-frontend/package-lock.json
+++ b/soci-frontend/package-lock.json
@@ -14,7 +14,8 @@
         "pug": "^3.0.1"
       },
       "devDependencies": {
-        "pug-cli": "^1.0.0-alpha6"
+        "pug-cli": "^1.0.0-alpha6",
+        "puppeteer-core": "^25.8.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -41,6 +42,115 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@types/babel-types": {
@@ -303,6 +413,23 @@
         "is-regex": "^1.0.3"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/clean-css": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
@@ -393,6 +520,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
@@ -405,6 +539,23 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -473,6 +624,29 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -729,6 +903,23 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/oauth-sign": {
@@ -1122,6 +1313,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer-core": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -1257,6 +1466,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -1318,6 +1573,13 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "2.8.29",
@@ -1392,6 +1654,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -1424,6 +1693,116 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yargs": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -1434,6 +1813,26 @@
         "cliui": "^2.1.0",
         "decamelize": "^1.0.0",
         "window-size": "0.1.0"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -1456,6 +1855,71 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@puppeteer/browsers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "dev": true,
+      "requires": {
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+          "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+          "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+          "dev": true,
+          "requires": {
+            "string-width": "^7.2.0",
+            "strip-ansi": "^7.1.0",
+            "wrap-ansi": "^9.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+              "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "yargs": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+          "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^9.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "string-width": "^8.2.1",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^22.0.0"
+          }
+        }
       }
     },
     "@types/babel-types": {
@@ -1670,6 +2134,16 @@
         "is-regex": "^1.0.3"
       }
     },
+    "chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "requires": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      }
+    },
     "clean-css": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
@@ -1743,6 +2217,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "devtools-protocol": {
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
+      "dev": true
+    },
     "doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
@@ -1756,6 +2236,18 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1808,6 +2300,18 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -2008,6 +2512,18 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
+    },
+    "modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
       "dev": true
     },
     "oauth-sign": {
@@ -2375,6 +2891,20 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "puppeteer-core": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "dev": true,
+      "requires": {
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      }
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -2469,6 +2999,33 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "requires": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+          "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        }
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -2515,6 +3072,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -2570,6 +3133,12 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
+    "webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -2593,6 +3162,64 @@
       "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+          "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+          "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        }
+      }
+    },
+    "ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "requires": {}
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yargs": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -2604,6 +3231,18 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
+    },
+    "yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true
     }
   }
 }

--- a/soci-frontend/package.json
+++ b/soci-frontend/package.json
@@ -25,6 +25,7 @@
     "pug": "^3.0.1"
   },
   "devDependencies": {
-    "pug-cli": "^1.0.0-alpha6"
+    "pug-cli": "^1.0.0-alpha6",
+    "puppeteer-core": "^25.8.0"
   }
 }

--- a/soci-frontend/pages/admin/settings.pug
+++ b/soci-frontend/pages/admin/settings.pug
@@ -16,7 +16,7 @@
     .block.password(load-order="tertiary")
       h2 Change Password
       form
-        soci-password(name="oldPassword" placeholder="Old password")
+        soci-password(no-entropy name="oldPassword" placeholder="Old password")
         soci-password(name="newPassword" placeholder="New password")
         soci-password(name="confirmPassword" match="newPassword" placeholder="Confirm new password")
         .actions

--- a/soci-frontend/soci.css
+++ b/soci-frontend/soci.css
@@ -2309,12 +2309,20 @@ soci-post-card soci-markdown-view code {
 /* Standard Modal Styles */
 soci-modal {
   .modal-form {
-    display: block;
+    /* flow-root so a floated child cannot escape the form and land underneath
+       whatever follows it in the modal. */
+    display: flow-root;
     min-width: min(420px, calc(100vw - 72px));
 
     soci-button {
       margin: 16px 0 8px;
       width: 100%;
+      /* soci-button floats itself, which suits a toolbar but not a full-width
+         form action: floated, it dropped out of flow and .modal-footer painted
+         over it, so a left-click on the visible button hit the footer link
+         instead of submitting. */
+      float: none;
+      display: block;
     }
   }
 

--- a/soci-frontend/test/browser.test.js
+++ b/soci-frontend/test/browser.test.js
@@ -1,0 +1,383 @@
+// Layout and hit-testing regressions, which only a real engine can catch:
+// reserving the post media box across the thumbnail -> full media swap, and
+// keeping the modal submit buttons clickable.
+//
+// Skipped when no Chrome is installed, so `npm test` still runs everywhere.
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { deflateSync } from 'node:zlib'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const PORT = 42200 + (process.pid % 100)
+const VIEWPORT = { width: 1000, height: 900 }
+const BOX = 800 // width of the harness container the media is mounted into
+
+const CHROME = [
+  process.env.PUPPETEER_EXECUTABLE_PATH,
+  process.env.CHROME_PATH,
+  '/usr/local/bin/google-chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+].find(p => p && fs.existsSync(p))
+
+let puppeteer
+try {
+  puppeteer = (await import('puppeteer-core')).default
+} catch {
+  puppeteer = null
+}
+
+// false, not null: node's runner skips on any `skip` other than undefined.
+const reason = !CHROME ? 'no Chrome installed' : !puppeteer ? 'puppeteer-core not installed' : false
+
+// -- a real bitmap of a given size, so the browser has an intrinsic ratio to
+// -- disagree with us about ------------------------------------------------
+const CRC = Int32Array.from({ length: 256 }, (_, n) => {
+  let c = n
+  for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+  return c
+})
+
+function chunk(type, data) {
+  const body = Buffer.concat([Buffer.from(type, 'ascii'), data])
+  let crc = ~0
+  for (const byte of body) crc = CRC[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  const len = Buffer.alloc(4)
+  len.writeUInt32BE(data.length)
+  const tail = Buffer.alloc(4)
+  tail.writeInt32BE(~crc)
+  return Buffer.concat([len, body, tail])
+}
+
+function png(width, height) {
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(width, 0)
+  ihdr.writeUInt32BE(height, 4)
+  ihdr[8] = 8 // 8-bit greyscale, which needs one byte per pixel and no palette
+  // One filter byte per row, then all-black pixels, which deflates to nothing.
+  const raw = Buffer.alloc((width + 1) * height)
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0))
+  ])
+}
+
+describe('browser', { skip: reason }, () => {
+  let server, browser, page
+
+  // The full image is held back so the thumbnail is provably on screen alone for
+  // a while; tests release it when they want the swap to happen. Releasing has
+  // to latch rather than just drain what is queued, because the browser may not
+  // have got round to asking for the full image yet.
+  let held = []
+  let holdFull = true
+  let served = {}
+  const releaseFull = () => {
+    holdFull = false
+    const queued = held
+    held = []
+    queued.forEach(respond => respond())
+  }
+
+  before(async () => {
+    if (!fs.existsSync(path.join(root, 'config.js')))
+      fs.copyFileSync(path.join(root, 'config.js.example'), path.join(root, 'config.js'))
+
+    server = spawn('node', ['index.js'], { cwd: root, env: { ...process.env, PORT } })
+    await new Promise((resolve, reject) => {
+      server.stdout.on('data', d => { if (d.toString().includes('listening')) resolve() })
+      server.on('error', reject)
+      setTimeout(() => reject(new Error('server did not start')), 10000)
+    })
+
+    browser = await puppeteer.launch({
+      executablePath: CHROME,
+      args: ['--no-sandbox', '--disable-dev-shm-usage']
+    })
+    page = await browser.newPage()
+    await page.setViewport(VIEWPORT)
+    await page.setCacheEnabled(false)
+    await page.setRequestInterception(true)
+    page.on('request', req => {
+      const url = req.url()
+      const image = url.match(/^http:\/\/localhost:4203\/(thumbnail\/)?fixture-\d+\.webp$/)
+      const poster = url.match(/^http:\/\/localhost:4204\/thumbnail\/fixture-\d+\.webp$/)
+      const thumb = () => served.thumb
+        ? req.respond({ contentType: 'image/png', body: png(...served.thumb) })
+        : req.respond({ status: 404 })
+      if (poster) return thumb()
+      if (image) {
+        if (image[1]) return thumb()
+        const respond = () => req.respond({ contentType: 'image/png', body: png(...served.full) })
+        if (!holdFull) return respond()
+        return new Promise(resolve => held.push(() => { respond(); resolve() }))
+      }
+      // The API is not running under test; failing fast beats a 30s timeout.
+      if (url.startsWith('http://localhost:4201')) return req.abort()
+      req.continue()
+    })
+    await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'domcontentloaded' })
+    await page.waitForFunction("customElements.get('soci-image') && customElements.get('soci-video')")
+  })
+
+  after(async () => {
+    await browser?.close()
+    server?.kill()
+  })
+
+  // Mount one media element in a fixed-width container and report the box it
+  // reserved before any of its media was fetched. Each mount gets its own url so
+  // one fixture's bitmap cannot be served to the next out of the cache.
+  let fixtures = 0
+  async function mount(tag, attrs, thumb, full) {
+    held = [] // requests from a torn-down element are nobody's to release
+    holdFull = true
+    served = { thumb, full }
+    const url = `fixture-${++fixtures}`
+    const reserved = await page.evaluate((tag, attrs, url, width) => {
+      document.querySelector('#harness')?.remove()
+      const harness = document.createElement('div')
+      harness.id = 'harness'
+      harness.style.cssText = `width:${width}px;position:absolute;top:0;left:0`
+      harness.innerHTML = `<${tag} ${attrs} url="${url}"></${tag}>`
+      document.body.appendChild(harness)
+      return window.__box(harness.firstElementChild)
+    }, tag, attrs, url, BOX)
+    return { reserved, url }
+  }
+
+  const box = el => page.evaluate(sel => window.__box(document.querySelector(sel)), el)
+
+  before(async () => {
+    // Rounded, because sub-pixel jitter is not a layout shift.
+    await page.evaluate(() => {
+      window.__box = el => {
+        const frame = el.shadowRoot.querySelector('#frame')
+        const r = frame.getBoundingClientRect()
+        return { width: Math.round(r.width), height: Math.round(r.height) }
+      }
+      window.__childBoxes = el => [...el.shadowRoot.querySelectorAll('#frame > *')].map(c => {
+        const r = c.getBoundingClientRect()
+        return { width: Math.round(r.width), height: Math.round(r.height), top: Math.round(r.top), left: Math.round(r.left) }
+      })
+    })
+  })
+
+  describe('post media reserves its box up front', () => {
+    test('stored dimensions reserve the box before any bitmap arrives', async () => {
+      const { reserved } = await mount('soci-image', 'width="1920" height="1080"', [256, 144], [1920, 1080])
+      // 16:9 inside an 800px container, and nothing has been fetched yet.
+      assert.deepEqual(reserved, { width: 800, height: 450 })
+
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#thumb').complete")
+      assert.deepEqual(await box('soci-image'), reserved, 'the thumbnail must not resize the box')
+
+      releaseFull()
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#image').complete")
+      assert.deepEqual(await box('soci-image'), reserved, 'the full image must not resize the box')
+    })
+
+    test('a portrait ratio is bounded by the height, not letterboxed into a wide box', async () => {
+      const { reserved } = await mount('soci-image', 'width="1080" height="1920"', [144, 256], [1080, 1920])
+      // 100vh - 100px is 800px tall here, so 9:16 gives a 450px wide box. A box
+      // sized from the container width instead would be 800x1422.
+      assert.deepEqual(reserved, { width: 450, height: 800 })
+
+      releaseFull()
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#image').complete")
+      assert.deepEqual(await box('soci-image'), reserved)
+    })
+
+    test('without stored dimensions the thumbnail locks the box, and the swap does not move it', async () => {
+      // 4:3, so a hardcoded 16:9 fallback would reserve 800x450 instead.
+      await mount('soci-image', '', [200, 150], [1000, 750])
+      await page.waitForFunction("document.querySelector('soci-image').hasAttribute('ratio')")
+      const locked = await box('soci-image')
+      assert.deepEqual(locked, { width: 800, height: 600 }, 'the box should take the thumbnail ratio')
+
+      releaseFull()
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#image').complete")
+      assert.deepEqual(await box('soci-image'), locked, 'the full image must not resize the box')
+    })
+
+    test('no ratio is invented when neither dimensions nor a thumbnail exist', async () => {
+      await mount('soci-image', '', null, [1000, 750])
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#thumb').complete")
+      assert.equal(
+        await page.evaluate(() => document.querySelector('soci-image').hasAttribute('ratio')),
+        false,
+        'a guessed ratio would reserve the wrong box'
+      )
+
+      // The full image is then the only thing left to measure.
+      releaseFull()
+      await page.waitForFunction("document.querySelector('soci-image').hasAttribute('ratio')")
+      assert.deepEqual(await box('soci-image'), { width: 800, height: 600 })
+    })
+
+    test('the thumbnail and the full image fill exactly the same box', async () => {
+      await mount('soci-image', 'width="1920" height="1080"', [256, 144], [1920, 1080])
+      releaseFull()
+      await page.waitForFunction("document.querySelector('soci-image').shadowRoot.querySelector('#image').complete")
+      const [thumb, full] = await page.evaluate(() => window.__childBoxes(document.querySelector('soci-image')))
+      assert.deepEqual(thumb, full, 'stacked sources must share one box')
+      assert.equal(
+        await page.evaluate(() => getComputedStyle(document.querySelector('soci-image').shadowRoot.querySelector('#image')).objectFit),
+        'contain'
+      )
+    })
+
+    test('video reserves its box and shows a poster while the video loads', async () => {
+      const { reserved, url } = await mount('soci-video', 'width="1920" height="1080"', [256, 144], [1920, 1080])
+      assert.deepEqual(reserved, { width: 800, height: 450 })
+      assert.equal(
+        await page.evaluate(() => document.querySelector('soci-video').shadowRoot.querySelector('video').poster),
+        `http://localhost:4204/thumbnail/${url}.webp`,
+        'the poster should come from the video CDN, not the image CDN'
+      )
+    })
+
+    test('without stored dimensions the video poster locks the box', async () => {
+      // 4:3 poster, so a 16:9 fallback would give 800x450 rather than 800x600.
+      await mount('soci-video', '', [200, 150], [1000, 750])
+      await page.waitForFunction("document.querySelector('soci-video').hasAttribute('ratio')")
+      assert.deepEqual(await box('soci-video'), { width: 800, height: 600 })
+    })
+
+    test('feed list tiles keep their fixed thumbnail box', async () => {
+      const tile = await page.evaluate(() => {
+        document.querySelector('#harness')?.remove()
+        const harness = document.createElement('div')
+        harness.id = 'harness'
+        harness.innerHTML = '<soci-post-li post-title="t" url="fixture" type="image"></soci-post-li>'
+        document.body.appendChild(harness)
+        const img = harness.firstElementChild.shadowRoot.querySelector('#thumbnail img')
+        const s = getComputedStyle(img)
+        return { width: s.width, height: s.height, fit: s.objectFit, loading: img.loading }
+      })
+      assert.deepEqual(tile, { width: '96px', height: '72px', fit: 'cover', loading: 'lazy' })
+    })
+  })
+
+  describe('modal submit buttons', () => {
+    const open = async name => {
+      await page.evaluate(n => { window.sociModals.closeAll(); return window.sociModals.open(n) }, name)
+      await page.waitForFunction("document.querySelector('soci-modal[active]')")
+    }
+
+    // The bug: soci-button floats itself, so inside .modal-form it left the
+    // form's flow and .modal-footer painted over it, swallowing the click.
+    const topmostAtCentre = sel => page.evaluate(s => {
+      const btn = document.querySelector(s)
+      const r = btn.getBoundingClientRect()
+      const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2)
+      return btn === top || btn.contains(top)
+    }, sel)
+
+    test('the login button receives clicks at its own centre', async () => {
+      await open('login')
+      assert.ok(await topmostAtCentre('#login-btn'), 'something is painted over the login button')
+    })
+
+    test('the login button sits inside its form, clear of the footer', async () => {
+      await open('login')
+      const { formBottom, btnBottom, footerTop } = await page.evaluate(() => {
+        const modal = document.querySelector('soci-login-modal')
+        return {
+          formBottom: modal.querySelector('form').getBoundingClientRect().bottom,
+          btnBottom: modal.querySelector('#login-btn').getBoundingClientRect().bottom,
+          footerTop: modal.querySelector('.modal-footer').getBoundingClientRect().top
+        }
+      })
+      assert.ok(btnBottom <= formBottom, 'the button escaped the form box')
+      assert.ok(formBottom <= footerTop, 'the form overlaps the footer')
+    })
+
+    test('the create account button receives clicks at its own centre', async () => {
+      await open('createAccount')
+      assert.ok(await topmostAtCentre('#register-btn'))
+    })
+
+    test('a left-click submits the login form with the entered credentials', async () => {
+      await open('login')
+      const submitted = await page.evaluate(async () => {
+        const modal = document.querySelector('soci-login-modal')
+        let payload = null
+        window.api.user.login = async data => { payload = data; return {} }
+        modal.querySelector('input[type="email"]').value = 'someone@example.com'
+        modal.querySelector('soci-password').value = 'correct horse'
+        const r = modal.querySelector('#login-btn').getBoundingClientRect()
+        document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2)
+          .dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))
+        await new Promise(res => setTimeout(res, 50))
+        return payload
+      })
+      assert.deepEqual(submitted, { email: 'someone@example.com', password: 'correct horse' })
+    })
+  })
+
+  describe('password entropy', () => {
+    const validity = (modal, name, value, useAutofill) => page.evaluate((modal, name, value, useAutofill) => {
+      const pw = document.querySelector(`${modal} soci-password[name="${name}"]`)
+      // Autofill assigns the inner input directly: no keystroke, no setter.
+      if (useAutofill) pw.field.value = value
+      else pw.value = value
+      pw.checkValidity()
+      return {
+        valid: pw.validity.valid,
+        message: pw.validationMessage,
+        inForm: new FormData(pw.closest('form')).get(name)
+      }
+    }, modal, name, value, useAutofill)
+
+    test('login accepts a password that predates the entropy requirement', async () => {
+      await page.evaluate(() => { window.sociModals.closeAll(); return window.sociModals.open('login') })
+      await page.waitForFunction("document.querySelector('soci-login-modal soci-password')")
+      const weak = await validity('soci-login-modal', 'password', 'hunter2')
+      assert.equal(weak.valid, true, 'login must not gate on password strength')
+      assert.equal(weak.message, '')
+    })
+
+    test('login hides the entropy meter, even while the field has focus', async () => {
+      assert.equal(
+        await page.evaluate(() => {
+          const pw = document.querySelector('soci-login-modal soci-password')
+          pw.field.focus()
+          return getComputedStyle(pw.shadowRoot.querySelector('svg')).display
+        }),
+        'none'
+      )
+    })
+
+    test('a password the browser autofilled still reaches the form', async () => {
+      const filled = await validity('soci-login-modal', 'password', 'autofilled-secret', true)
+      assert.equal(filled.inForm, 'autofilled-secret', 'autofill never fires a keystroke')
+    })
+
+    test('registration still requires 40 bits of entropy', async () => {
+      await page.evaluate(() => { window.sociModals.closeAll(); return window.sociModals.open('createAccount') })
+      await page.waitForFunction("document.querySelector('soci-create-account-modal soci-password')")
+      const weak = await validity('soci-create-account-modal', 'password', 'hunter2')
+      assert.equal(weak.valid, false)
+      assert.match(weak.message, /Not strong enough/)
+
+      const strong = await validity('soci-create-account-modal', 'password', 'Tr0ub4dor&3xample!')
+      assert.equal(strong.valid, true)
+      assert.equal(strong.inForm, 'Tr0ub4dor&3xample!')
+    })
+
+    test('registration still requires the confirmation to match', async () => {
+      await validity('soci-create-account-modal', 'password', 'Tr0ub4dor&3xample!')
+      const mismatch = await validity('soci-create-account-modal', 'confirmPassword', 'Tr0ub4dor&3xampl3!')
+      assert.equal(mismatch.valid, false)
+      assert.match(mismatch.message, /do not match/)
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two independent frontend bugs in `soci-frontend`. Do not merge.

## 1. Post media resized itself mid-load

`soci-image` pointed one `<img>` at the thumbnail and then re-pointed the same element at the full image, so the media area was sized by whichever bitmap happened to be decoded — the 192x144 thumbnail first, then the full image. `soci-video` had no poster at all and sized itself off the `<video>` 300x150 default until metadata arrived. Either way everything below the media snapped down the page.

Fixed with a shared ratio-locked box, `soci-frontend/lib/media-frame.js` (`MEDIA_FRAME_CSS` + `lockRatio`). The frame takes its height from `aspect-ratio` alone and stacks its sources absolutely with `object-fit: contain`, so the thumbnail and the full media occupy the same box and the swap changes no layout.

Ratio sources, in order, never guessed:

1. Stored post `width`/`height`, now threaded from `soci-post` as attributes, so the box is final before a single byte is requested.
2. Else the thumbnail's (image) or poster's (video) intrinsic ratio, as soon as it is known.
3. Else the full image, or the video's `loadedmetadata`.

Width is additionally capped by the ratio against the height bound. Without that, `aspect-ratio` resolves width from the container first and a portrait post reserves a box wider than its own media, letterboxing itself.

Measured on the same pages under the same throttling — movement of the post title across the thumbnail → full-media swap:

| Post | Before | After |
|---|---|---|
| image 1920x1080 | 419px | **0px** |
| image 1080x1920 (portrait) | 544px | **0px** |
| image, no stored dimensions | 419px | **0px** |
| video 1280x720 | 413px | **0px** |

[Before and after comparison of the post media area at the thumbnail and full-image stages](https://cursor.com/agents/bc-4538bbd3-4776-4620-90ba-7dcb00a3dd0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmedia_cls_before_after.png)

Also removed from `soci-post`, all of it unreachable: the `#image` block sitting behind `soci-image`, which carried `style="display: none"` inline and so could never show but did duplicate both CDN requests; its `_zoomImage` handler (`this.select()` with no selector, which throws); and the CSS that only styled it.

Feed tiles are deliberately untouched and pinned by a test — `soci-post-li` keeps its fixed 96x72 `object-fit: cover` thumbnail, and `soci-post-card` is unchanged. Click-to-zoom (fit 1000x563 → natural 1920x1080 with scrolling, and back), the blurred backdrop, video playback, the resolution ladder and the controls were all re-checked against the running app.

## 2. The login submit button could not be left-clicked, though Enter worked

Not an overlay, a `disabled` state, or `pointer-events`. `soci-button` sets `float: right` on its own `:host`, and `.modal-form` had no clearfix, so the full-width login button left the form's flow and `.modal-footer` — a later sibling — painted over it. Measured on master, at the button's own visual centre:

```
btnRect:                 { y: 495, h: 20 }     // button spans 495..515
footerRect:              { top: 503 }          // footer starts 12px into it
topElementAtBtnCenter:   "soci-link#create-account"
btnIsTop:                false
```

So a left-click landed on the "create account" link and swapped the modal instead of submitting. Enter worked because it never goes near the button — the modal handles it on `keydown`. Fixed in `soci.css` by un-floating `soci-button` inside `.modal-form` and making the form a `flow-root` so no other floated child can escape it either.

The stated hypothesis (a speed-lab patch that skipped entropy via `no-entropy` and input/change sync) is **not in this repository** — `git log --all -S "no-entropy"` returns nothing, and no speed-lab branch touches `soci-password.js` or `soci-login-modal.js`. But it described two real problems, both found while confirming the click cause:

- **Login ran the 40-bit entropy gate** meant for *choosing* a password, so a weak-but-correct existing password failed `form.reportValidity()` and could not be submitted at all, by click or by Enter. `soci-password` now takes `no-entropy`, applied to login and to the "old password" field in admin settings, which had the same lockout. Register keeps the gate, the meter, and the confirm-match check.
- **Autofill never reached the payload.** The form value was published only from `keydown`/`keyup`, which a browser-filled value does not fire. It now syncs on `input`/`change`, and in `checkValidity` — the hook callers use immediately before reading the form.

Also dropped a leftover debug rule in `soci-password` that painted a red 10x10 square inside the field whenever the host had focus.

End-to-end against the running app: left-click on the button submits, the modal closes, and the sidebar switches to the logged-in state. No strength ring on the login field, and it accepts a weak password.

[login_button_left_click_submits_and_logs_in.mp4](https://cursor.com/agents/bc-4538bbd3-4776-4620-90ba-7dcb00a3dd0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_button_left_click_submits_and_logs_in.mp4)

## Tests

`soci-frontend/test/browser.test.js` — 17 cases driving real Chrome via `puppeteer-core`. It fixtures the CDNs by request interception with generated PNGs, so each fixture's intrinsic size is whatever the case needs, and holds the full image back so the thumbnail is provably on screen alone before the swap.

**11 of the 17 fail against the pre-fix code**; the 6 that pass either way are the "must not change" guards (feed tiles, the register gate, confirm-match, the register button's hit target).

`puppeteer-core` is a devDependency and the suite skips itself when no Chrome is installed (`ok 1 - browser # SKIP no Chrome installed`, hooks included), so `npm test` still passes anywhere. Frontend `npm test`: **29/29**.

### Manual test note

Requires the full stack (`./quickStart.sh`).

**Media, on a post page for an image or video post:** the media area should be the right size and shape from the first paint, filled by the thumbnail or poster, and the full media should fade in over it without the title, tags, or comments moving. Worth checking a portrait post (the box should be bounded by the viewport height, not letterboxed into a full-width box), a landscape post, and a video. Click-to-zoom and the video resolution switcher, fullscreen, and seek should behave as before. In DevTools, Performance → Experience should show no layout-shift record for the media swap, and feed rows should still be 96x72 thumbnails that expand on click.

**Login:** open the login modal from the sidebar and click "login" with the left mouse button. It should submit — spinner, then success or the red error shake — and must not swap to the create-account modal. The password field should show no entropy ring, and a password that is merely correct should be accepted. Let the browser autofill the credentials and click submit without typing: the request should carry the password. Then check the create-account modal still refuses a weak password and still shows the ring filling as the password strengthens.

### Out of scope

A separate, pre-existing layout shift remains when a post is first mounted: `#media-container` goes from zero height to its reserved box when the post JSON lands, since nothing knows the dimensions before the response. That accounts for the ~0.28 residual CLS measured on both sides of this change, and it is unrelated to the thumbnail → full-media swap this PR fixes.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4538bbd3-4776-4620-90ba-7dcb00a3dd0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4538bbd3-4776-4620-90ba-7dcb00a3dd0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

