### PR TITLE
Lazy per-route component graph (no WS)

### DIFF
--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -1,3 +1,46 @@
+## 2026-08-25 — Lazy per-route component graph, split out for review (branch `cursor/lazy-per-route-component-graph-5cc4`)
+
+The loader half of `cursor/lazy-graph-ws-notifications-663d` (PR #172), rebased
+onto master on its own so the first-paint win can be reviewed and landed
+without the websocket-notification feature riding along. Frontend only — no
+backend routes, no `soci-notification-badge` changes, no edge playbook. PR #172
+stays open for the websocket half.
+
+- **Lazy per-route component graph.** `soci-components.js` no longer imports
+  all ~65 modules (502 KB raw / 140 KB gz) before first paint; it eagerly
+  defines only the 17-module shell (routing, sidebar, icon/link/button/user/
+  select/tag-li/badge/modal + modal manager). New `components/soci-loader.js`
+  holds an element→module registry plus per-route packs (`PACKS`, keyed by
+  `soci-route` id) and modal packs; `soci-route.activate()` awaits
+  `routeReady(id)` before dispatching `routeactivate`, so page scripts never
+  race `customElements.define` (elements upgrade in place; observed
+  attributes replay at upgrade). An activation token drops a stale pack that
+  lands after you've navigated away, and `deactivate()` now also cleans up a
+  route still in its `activating` phase. Failed imports resolve anyway (the
+  route still activates) and are retried on the next `ensure()`.
+- **Where the lazy loads hang off:** modals through the modal manager's
+  existing `load` hook, sidebar channel rows on first render, and everything
+  else warming after `load` + idle so SPA navs stay instant (skipped under
+  `saveData`; sequential on purpose so 40 imports don't compete with feed
+  media). `#pages :not(:defined) { display: none }` in `soci.css` guards
+  light-DOM flashes (e.g. submit's tab contents) pre-upgrade.
+- **Measured** on the seeded local stack, slow4g lane, medians of 7: home
+  cold FCP 2656→1348 ms (−49%), LCP 2716→1800 (−34%), feedPaint 3234→2266
+  (−30%); post deep link FCP 2512→1332 (−47%), LCP 2804→2056 (−27%); 31
+  modules at feed paint instead of 68. Warm loads and SPA transitions
+  unchanged.
+- **Tests:** `soci-frontend/test/loader.test.js` (registry completeness
+  against every template/script, packs name real modules, every route id has
+  a pack, core never statically imports a lazy module, no element both eager
+  and lazy) and `speed-lab/harness/probe-lazy.mjs` (browser phase
+  assertions). `npm test` in soci-frontend: 18/18 green.
+- **quickStart.sh fix** carried along because the lazy graph can't be
+  exercised without a running stack: CDN builds now compile the whole package
+  (`go build -o X .`), not just `main.go` — the cache-control helpers added in
+  the perf pass live in sibling files, so the old command no longer built.
+- Thumbnail srcset/HEIC handling and every other speed keeper on master are
+  untouched by this branch.
+
 ## 2026-08-24 — VPS speed lab: live deploy + measured perf loop (branch `cursor/speed-vps-loop-27f0`)
 
 Deployed the monorepo to a live 1-vCPU/1 GB Vultr box (108.61.219.46) with a

--- a/quickStart.sh
+++ b/quickStart.sh
@@ -34,8 +34,10 @@ fi
 
 screen -AdmS soci -t frontend bash -c "bash --init-file <(echo 'cd soci-frontend; npm i; npm start;')"
 screen -S soci -X screen -t api bash -c "bash --init-file <(echo 'cd soci-backend; ./localRun.sh')"
-screen -S soci -X screen -t avatar-cdn bash -c "bash --init-file <(echo 'cd soci-avatar-cdn; go build -o avatar-cdn main.go; ./avatar-cdn')"
-screen -S soci -X screen -t image-cdn bash -c "bash --init-file <(echo 'cd soci-image-cdn; go build -o image-cdn main.go; ./image-cdn')"
-screen -S soci -X screen -t video-cdn bash -c "bash --init-file <(echo 'cd soci-video-cdn; go build -o video-cdn main.go; ./video-cdn')"
-screen -S soci -X screen -t html-cdn bash -c "bash --init-file <(echo 'cd soci-html-cdn; go build -o html-cdn main.go; ./html-cdn')"
+# Build the whole package (not just main.go): the CDNs split helpers like
+# cacheControl into sibling files, which a bare main.go build can't see.
+screen -S soci -X screen -t avatar-cdn bash -c "bash --init-file <(echo 'cd soci-avatar-cdn; go build -o avatar-cdn .; ./avatar-cdn')"
+screen -S soci -X screen -t image-cdn bash -c "bash --init-file <(echo 'cd soci-image-cdn; go build -o image-cdn .; ./image-cdn')"
+screen -S soci -X screen -t video-cdn bash -c "bash --init-file <(echo 'cd soci-video-cdn; go build -o video-cdn .; ./video-cdn')"
+screen -S soci -X screen -t html-cdn bash -c "bash --init-file <(echo 'cd soci-html-cdn; go build -o html-cdn .; ./html-cdn')"
 screen -rD soci

--- a/soci-frontend/components/modals/soci-modal-manager.js
+++ b/soci-frontend/components/modals/soci-modal-manager.js
@@ -1,28 +1,39 @@
+import { ensure, MODAL_PACKS } from '../soci-loader.js'
+
+// Modal components stay out of the eager graph; each entry's `load` pulls
+// its pack the first time the modal opens.
+const lazy = name => () => ensure(MODAL_PACKS[name])
+
 const modalRegistry = {
   login: {
     id: 'login-modal',
     title: 'Login',
-    tag: 'soci-login-modal'
+    tag: 'soci-login-modal',
+    load: lazy('login')
   },
   createAccount: {
     id: 'create-account-modal',
     title: 'Create account',
-    tag: 'soci-create-account-modal'
+    tag: 'soci-create-account-modal',
+    load: lazy('createAccount')
   },
   createCommunity: {
     id: 'create-community-modal',
     title: 'Create community',
-    tag: 'soci-create-community-modal'
+    tag: 'soci-create-community-modal',
+    load: lazy('createCommunity')
   },
   createChannel: {
     id: 'create-channel-modal',
     title: 'Create channel',
-    tag: 'soci-create-channel-modal'
+    tag: 'soci-create-channel-modal',
+    load: lazy('createChannel')
   },
   imageViewer: {
     id: 'image-viewer-modal',
     title: 'Image viewer',
-    tag: 'soci-image-viewer-modal'
+    tag: 'soci-image-viewer-modal',
+    load: lazy('imageViewer')
   }
 }
 

--- a/soci-frontend/components/soci-components.js
+++ b/soci-frontend/components/soci-components.js
@@ -1,64 +1,25 @@
-import SociComponent from './soci-component.js'
+/* Eager shell: only what paints above the fold on every route — routing,
+ * sidebar, and the chrome primitives they slot. Everything else is defined
+ * lazily by soci-loader.js: per-route packs load when a route activates
+ * (soci-route awaits routeReady before dispatching routeactivate), modal
+ * packs load when a modal opens, and the remainder warms up after the page
+ * is idle. Keep this list lean — every import here gates first paint. */
+import { warmup } from './soci-loader.js'
 
 import SociRoute from "./soci-route.js"
 window.customElements.define('soci-route', SociRoute)
 
-import SociRouter from "./soci-router.js"
-window.sociRouter = new SociRouter()
-
-import SociAvatarUploader from "./soci-avatar-uploader.js"
-window.customElements.define('soci-avatar-uploader', SociAvatarUploader)
-
-import SociBanner from "./soci-banner.js"
-window.customElements.define('soci-banner', SociBanner)
-
-import SociButton from "./soci-button.js"
-window.customElements.define('soci-button', SociButton)
-
-import SociComment from "./soci-comment.js"
-window.customElements.define('soci-comment', SociComment)
-
-import SociContributionSlider from "./soci-contribution-slider.js"
-window.customElements.define('soci-contribution-slider', SociContributionSlider)
-
-import SociCommentList from "./soci-comment-list.js"
-window.customElements.define('soci-comment-list', SociCommentList)
-
-import SociHTMLPage from "./soci-html-page.js"
-window.customElements.define('soci-html-page', SociHTMLPage)
-
-import SociHTMLUploader from "./soci-html-uploader.js"
-window.customElements.define('soci-html-uploader', SociHTMLUploader)
-
 import SociIcon from "./soci-icon.js"
 window.customElements.define('soci-icon', SociIcon)
-
-import SociEmoji from "./soci-emoji.js"
-window.customElements.define('soci-emoji', SociEmoji)
-
-import SociImage from "./soci-image.js"
-window.customElements.define('soci-image', SociImage)
-
-import SociImageUploader from "./soci-image-uploader.js"
-window.customElements.define('soci-image-uploader', SociImageUploader)
-
-import SociInput from "./soci-input.js"
-window.customElements.define('soci-input', SociInput)
-
-import SociLedgerLi from "./soci-ledger-li.js"
-window.customElements.define('soci-ledger-li', SociLedgerLi)
-
-import SociLedgerMonth from "./soci-ledger-month.js"
-window.customElements.define('soci-ledger-month', SociLedgerMonth)
-
-import SociLedger from "./soci-ledger.js"
-window.customElements.define('soci-ledger', SociLedger)
 
 import SociLink from "./soci-link.js"
 window.customElements.define('soci-link', SociLink)
 
-import SociLinkInput from "./soci-link-input.js"
-window.customElements.define('soci-link-input', SociLinkInput)
+import SociButton from "./soci-button.js"
+window.customElements.define('soci-button', SociButton)
+
+import SociUser from "./soci-user.js"
+window.customElements.define('soci-user', SociUser)
 
 import SociModal from "./soci-modal.js"
 window.customElements.define('soci-modal', SociModal)
@@ -66,39 +27,12 @@ window.customElements.define('soci-modal', SociModal)
 import SociNotificationBadge from "./soci-notification-badge.js"
 window.customElements.define('soci-notification-badge', SociNotificationBadge)
 
-import SociMarkdownView from "./soci-markdown-view.js"
-window.customElements.define('soci-markdown-view', SociMarkdownView)
-
-import SociMessageRow from "./soci-message-row.js"
-window.customElements.define('soci-message-row', SociMessageRow)
-
-import SociPassword from "./soci-password.js"
-window.customElements.define('soci-password', SociPassword)
-
-import SociPost from "./soci-post.js"
-window.customElements.define('soci-post', SociPost)
-
-import SociPostLi from "./soci-post-li.js"
-window.customElements.define('soci-post-li', SociPostLi)
-
-import SociPostCard from "./soci-post-card.js"
-window.customElements.define('soci-post-card', SociPostCard)
-
-import SociPostList from "./soci-post-list.js"
-window.customElements.define('soci-post-list', SociPostList)
-
 import {SociSelect, SociOption} from "./soci-select.js"
 window.customElements.define('soci-select', SociSelect)
 window.customElements.define('soci-option', SociOption)
 
-import SociRadioButton from "./soci-radio-button.js"
-window.customElements.define('soci-radio-button', SociRadioButton)
-
-import SociRadioButtonGroup from "./soci-radio-button-group.js"
-window.customElements.define('soci-radio-button-group', SociRadioButtonGroup)
-
-import SociRadialProgress from "./soci-radial-progress.js"
-window.customElements.define('soci-radial-progress', SociRadialProgress)
+import SociTagLi from "./soci-tag-li.js"
+window.customElements.define('soci-tag-li', SociTagLi)
 
 import SociSidebar from "./soci-sidebar.js"
 window.customElements.define('soci-sidebar', SociSidebar)
@@ -111,70 +45,11 @@ window.customElements.define('soci-sidebar-panel', SociSidebarPanel)
 window.customElements.define('soci-sidebar-community-panel', SociSidebarCommunityPanel)
 window.customElements.define('soci-sidebar-user-panel', SociSidebarUserPanel)
 
-import SociLoginModal from "./modals/soci-login-modal.js"
-window.customElements.define('soci-login-modal', SociLoginModal)
-
-import SociCreateAccountModal from "./modals/soci-create-account-modal.js"
-window.customElements.define('soci-create-account-modal', SociCreateAccountModal)
-
-import SociCreateCommunityModal from "./modals/soci-create-community-modal.js"
-window.customElements.define('soci-create-community-modal', SociCreateCommunityModal)
-
-import SociCreateChannelModal from "./modals/soci-create-channel-modal.js"
-window.customElements.define('soci-create-channel-modal', SociCreateChannelModal)
-
-import SociImageViewerModal from "./modals/soci-image-viewer-modal.js"
-window.customElements.define('soci-image-viewer-modal', SociImageViewerModal)
-
 import "./modals/soci-modal-manager.js"
 
-import SociTab from "./soci-tab.js"
-window.customElements.define('soci-tab', SociTab)
+// Routes upgrade on the define above; instantiating the router activates the
+// current route, whose activate() kicks off its lazy pack immediately.
+import SociRouter from "./soci-router.js"
+window.sociRouter = new SociRouter()
 
-import SociTabGroup from "./soci-tab-group.js"
-window.customElements.define('soci-tab-group', SociTabGroup)
-
-import SociTag from "./soci-tag.js"
-window.customElements.define('soci-tag', SociTag)
-
-import SociTagGroup from "./soci-tag-group.js"
-window.customElements.define('soci-tag-group', SociTagGroup)
-
-import SociTagLi from "./soci-tag-li.js"
-window.customElements.define('soci-tag-li', SociTagLi)
-
-import SociUrlInput from "./soci-url-input.js"
-window.customElements.define('soci-url-input', SociUrlInput)
-
-import SociVoiceChannelLi from "./soci-voice-channel-li.js"
-window.customElements.define('soci-voice-channel-li', SociVoiceChannelLi)
-
-import SociTextChannelLi from "./soci-text-channel-li.js"
-window.customElements.define('soci-text-channel-li', SociTextChannelLi)
-
-import SociTextChannelViewThreaded from "./soci-text-channel-view-threaded.js"
-window.customElements.define('soci-text-channel-view', SociTextChannelViewThreaded)
-
-import SociUsernameInput from "./soci-username-input.js"
-window.customElements.define('soci-username-input', SociUsernameInput)
-
-import SociUser from "./soci-user.js"
-window.customElements.define('soci-user', SociUser)
-
-import SociUserPicker from "./soci-user-picker.js"
-window.customElements.define('soci-user-picker', SociUserPicker)
-
-import SociUserComment from "./soci-user-comment.js"
-window.customElements.define('soci-user-comment', SociUserComment)
-
-import SociUserCommentList from "./soci-user-comment-list.js"
-window.customElements.define('soci-user-comment-list', SociUserCommentList)
-
-import SociVideo from "./soci-video.js"
-window.customElements.define('soci-video', SociVideo)
-
-import SociVideoUploader from "./soci-video-uploader.js"
-window.customElements.define('soci-video-uploader', SociVideoUploader)
-
-import SociEncodingProgress from "./soci-encoding-progress.js"
-window.customElements.define('soci-encoding-progress', SociEncodingProgress)
+warmup()

--- a/soci-frontend/components/soci-loader.js
+++ b/soci-frontend/components/soci-loader.js
@@ -1,0 +1,144 @@
+/* Lazy custom-element loader.
+ *
+ * soci-components.js used to statically import all ~65 modules (~500 KB raw),
+ * and ES module semantics meant nothing executed until the slowest import
+ * arrived — every route paid for the whole graph before first paint. Now only
+ * the shell (sidebar, routing, chrome) is eager; everything else is defined
+ * on demand from this registry.
+ *
+ * Elements upgrade in place when their definition lands, so route DOM can
+ * attach before its modules arrive. soci-route delays `routeactivate` (where
+ * page scripts call component methods) until routeReady() resolves, which
+ * keeps upgrade timing invisible to page code. A failed import resolves
+ * anyway (the route still activates) and is retried on the next request.
+ */
+
+// element name -> module path. Modules here export the class as default.
+export const REGISTRY = {
+  'soci-avatar-uploader': './soci-avatar-uploader.js',
+  'soci-banner': './soci-banner.js',
+  'soci-comment': './soci-comment.js',
+  'soci-comment-list': './soci-comment-list.js',
+  'soci-contribution-slider': './soci-contribution-slider.js',
+  'soci-emoji': './soci-emoji.js',
+  'soci-encoding-progress': './soci-encoding-progress.js',
+  'soci-html-page': './soci-html-page.js',
+  'soci-html-uploader': './soci-html-uploader.js',
+  'soci-image': './soci-image.js',
+  'soci-image-uploader': './soci-image-uploader.js',
+  'soci-input': './soci-input.js',
+  'soci-ledger': './soci-ledger.js',
+  'soci-ledger-li': './soci-ledger-li.js',
+  'soci-ledger-month': './soci-ledger-month.js',
+  'soci-link-input': './soci-link-input.js',
+  'soci-markdown-view': './soci-markdown-view.js',
+  'soci-message-row': './soci-message-row.js',
+  'soci-password': './soci-password.js',
+  'soci-post': './soci-post.js',
+  'soci-post-card': './soci-post-card.js',
+  'soci-post-li': './soci-post-li.js',
+  'soci-post-list': './soci-post-list.js',
+  'soci-radial-progress': './soci-radial-progress.js',
+  'soci-radio-button': './soci-radio-button.js',
+  'soci-radio-button-group': './soci-radio-button-group.js',
+  'soci-tab': './soci-tab.js',
+  'soci-tab-group': './soci-tab-group.js',
+  'soci-tag': './soci-tag.js',
+  'soci-tag-group': './soci-tag-group.js',
+  'soci-text-channel-li': './soci-text-channel-li.js',
+  'soci-text-channel-view': './soci-text-channel-view-threaded.js',
+  'soci-url-input': './soci-url-input.js',
+  'soci-user-comment': './soci-user-comment.js',
+  'soci-user-comment-list': './soci-user-comment-list.js',
+  'soci-user-picker': './soci-user-picker.js',
+  'soci-username-input': './soci-username-input.js',
+  'soci-video': './soci-video.js',
+  'soci-video-uploader': './soci-video-uploader.js',
+  'soci-voice-channel-li': './soci-voice-channel-li.js',
+  'soci-login-modal': './modals/soci-login-modal.js',
+  'soci-create-account-modal': './modals/soci-create-account-modal.js',
+  'soci-create-community-modal': './modals/soci-create-community-modal.js',
+  'soci-create-channel-modal': './modals/soci-create-channel-modal.js',
+  'soci-image-viewer-modal': './modals/soci-image-viewer-modal.js'
+}
+
+// Shared element groups, composed into per-route packs below.
+const FEED = ['soci-post-list', 'soci-post-li', 'soci-post-card', 'soci-tag-group', 'soci-tag', 'soci-markdown-view', 'soci-emoji', 'soci-radio-button', 'soci-radio-button-group']
+const COMMENTS = ['soci-comment', 'soci-comment-list', 'soci-input', 'soci-markdown-view', 'soci-emoji']
+const USER_COMMENTS = ['soci-user-comment-list', 'soci-user-comment', ...COMMENTS]
+
+// route id (soci-route#id in index.pug) -> elements it needs to paint.
+export const PACKS = {
+  'tags': FEED,
+  'post': ['soci-post', 'soci-tag-group', 'soci-tag', 'soci-video', 'soci-image', 'soci-html-page', 'soci-encoding-progress', 'soci-radial-progress', ...COMMENTS],
+  'user': [...FEED, ...USER_COMMENTS],
+  'notifications': USER_COMMENTS,
+  'submit': ['soci-url-input', 'soci-tab', 'soci-tab-group', 'soci-link-input', 'soci-image-uploader', 'soci-video-uploader', 'soci-html-uploader', 'soci-encoding-progress', 'soci-radial-progress', 'soci-input', 'soci-emoji', 'soci-post-li', 'soci-tag-group', 'soci-tag', 'soci-markdown-view'],
+  'text-channel': ['soci-text-channel-view', 'soci-message-row', 'soci-input', 'soci-emoji', 'soci-markdown-view', 'soci-image'],
+  'admin-create': [],
+  'admin-subscribe': ['soci-contribution-slider'],
+  'admin-forgot-password': [],
+  'admin-change-forgotten-password': ['soci-password'],
+  'admin-settings': ['soci-avatar-uploader', 'soci-password', 'soci-input', 'soci-emoji'],
+  'admin-financials': ['soci-ledger', 'soci-ledger-month', 'soci-ledger-li', 'soci-banner', 'soci-input', 'soci-emoji'],
+  'admin-emojis': ['soci-emoji'],
+  'about': [],
+  'privacy-policy': [],
+  'contact': [],
+  'community-settings': ['soci-avatar-uploader', 'soci-input', 'soci-emoji', 'soci-radio-button-group', 'soci-radio-button'],
+  'community-users': ['soci-user-picker'],
+  'community-financials': [],
+  'community-emojis': ['soci-emoji']
+}
+
+// modal name (soci-modal-manager registry) -> elements the modal mounts.
+export const MODAL_PACKS = {
+  login: ['soci-login-modal', 'soci-password'],
+  createAccount: ['soci-create-account-modal', 'soci-username-input', 'soci-password'],
+  createCommunity: ['soci-create-community-modal'],
+  createChannel: ['soci-create-channel-modal', 'soci-radio-button-group', 'soci-radio-button'],
+  imageViewer: ['soci-image-viewer-modal']
+}
+
+const pending = new Map()
+
+function load(name) {
+  if (customElements.get(name)) return Promise.resolve()
+  const path = REGISTRY[name]
+  if (!path) return Promise.resolve()
+  if (pending.has(name)) return pending.get(name)
+
+  const p = import(path)
+    .then(m => {
+      if (!customElements.get(name)) customElements.define(name, m.default)
+    })
+    .catch(err => {
+      // Resolve so routes still activate; forget the attempt so a later
+      // ensure() retries instead of caching the failure forever.
+      pending.delete(name)
+      console.warn(`soci-loader: failed to load <${name}>`, err)
+    })
+  pending.set(name, p)
+  return p
+}
+
+export function ensure(names) {
+  return Promise.all((names || []).map(load))
+}
+
+export function routeReady(routeId) {
+  return ensure(PACKS[routeId])
+}
+
+// Warm the rest of the registry once the page is idle, so later SPA
+// navigations find their definitions already local. Sequential on purpose:
+// a burst of 40 imports would compete with lazy-loading feed media.
+export function warmup() {
+  if (navigator.connection?.saveData) return
+  const idle = window.requestIdleCallback || (cb => setTimeout(cb, 2000))
+  const run = async () => {
+    for (const name of Object.keys(REGISTRY)) await load(name)
+  }
+  if (document.readyState === 'complete') idle(run)
+  else window.addEventListener('load', () => idle(run), { once: true })
+}

--- a/soci-frontend/components/soci-route.js
+++ b/soci-frontend/components/soci-route.js
@@ -1,4 +1,5 @@
 import SociComponent from './soci-component.js'
+import { routeReady } from './soci-loader.js'
 
 export default class SociRouter extends SociComponent {
   constructor() {
@@ -61,33 +62,32 @@ export default class SociRouter extends SociComponent {
     }
     else this._attachChildren()
 
-    // TODO
-    // Hypothesis: we could dynamically load tags and match them to files, potentially speeding up first page load time. 
-    // Definitely would need to be benchmarked to see if this works. 
-    /*
-    this.innerHTML.match(/<soci-(\w+)[^>]*>/g).forEach(tag => {
-      let name = tag.match(/<soci-(\w+)[^>]*>/)[1]
-      console.log(name)
-      import(`./soci-${name}.js`).then(module => {
-        window.customElements.define(`soci-${name}`, module.default)
-      })
-
-    })
-    */
-
     // Very briefly add the activating class, followed immediately by the active
     // class. This allows us to bind animation transitions easily for page loads.
+    //
+    // `active` and routeactivate wait for the route's lazy element pack, so
+    // page scripts listening to routeactivate can call component methods
+    // without racing customElements.define. The token guards against a
+    // navigation away (or a re-activation) while the pack is in flight.
     this.setAttribute('activating', '')
-    setTimeout(()=>{
-      this.removeAttribute('activating')
-      this.setAttribute('active', '')
-      let e = new CustomEvent('routeactivate', {bubbles: false})
-      this.dispatchEvent(e)
-    },1)
+    const token = this._activationToken = Symbol()
+    routeReady(this.id).then(()=>{
+      if(this._activationToken !== token) return
+      setTimeout(()=>{
+        if(this._activationToken !== token) return
+        this.removeAttribute('activating')
+        this.setAttribute('active', '')
+        let e = new CustomEvent('routeactivate', {bubbles: false})
+        this.dispatchEvent(e)
+      },1)
+    })
   }
 
   deactivate(){
-    if(this.hasAttribute('active')){
+    this._activationToken = null
+    const wasActivating = this.hasAttribute('activating')
+    this.removeAttribute('activating')
+    if(this.hasAttribute('active') || wasActivating){
       this.removeAttribute('active')
       this._detachChildren()
 

--- a/soci-frontend/components/soci-sidebar.js
+++ b/soci-frontend/components/soci-sidebar.js
@@ -1,6 +1,7 @@
 import SociComponent from './soci-component.js'
 import config from '../config.js'
 import sociModalManager from './modals/soci-modal-manager.js'
+import { ensure } from './soci-loader.js'
 
 export default class SociSidebar extends SociComponent {
   constructor() {
@@ -299,6 +300,8 @@ export default class SociSidebar extends SociComponent {
       const res = await window.api.channels.list(community)
       const channels = res?.channels || []
       list.innerHTML = ''
+      // Channel rows are lazy; they upgrade in place once these land.
+      if(channels.length) ensure(['soci-text-channel-li', 'soci-voice-channel-li'])
       channels.forEach(ch => {
         if(ch.kind === 'voice') {
           const li = document.createElement('soci-voice-channel-li')

--- a/soci-frontend/soci.css
+++ b/soci-frontend/soci.css
@@ -632,6 +632,13 @@ soci-message-row button:hover {
   width: calc(100vw - 280px);
   position: relative;
   margin-left: 280px;
+
+  /* Custom elements are defined lazily per route; hide any element whose
+     definition hasn't landed yet so light-DOM children (e.g. submit's tab
+     contents) can't flash unstyled before upgrade. */
+  :not(:defined) {
+    display: none;
+  }
 }
 #pages:before {
   content: '';

--- a/soci-frontend/test/loader.test.js
+++ b/soci-frontend/test/loader.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The lazy loader's registry and packs are static data; these tests keep the
+// split component graph honest: every element used anywhere must be defined
+// either eagerly (core shell) or through the loader, packs must only name
+// real registry entries, and the core must never statically import a module
+// the registry lazy-loads.
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const read = f => fs.readFileSync(path.join(root, f), 'utf8')
+
+const { REGISTRY, PACKS, MODAL_PACKS } = await import('../components/soci-loader.js')
+
+const componentsSrc = read('components/soci-components.js')
+const coreDefines = [...componentsSrc.matchAll(/customElements\.define\('([^']+)'/g)].map(m => m[1])
+const known = new Set([...coreDefines, ...Object.keys(REGISTRY)])
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(path.join(root, dir), { withFileTypes: true })) {
+    const rel = path.join(dir, entry.name)
+    if (entry.isDirectory()) yield* walk(rel)
+    else if (/\.(js|pug|html)$/.test(entry.name)) yield rel
+  }
+}
+
+const scanFiles = ['index.pug', 'sidebar.pug', 'soci.js', ...walk('pages'), ...walk('components'), ...walk('lib')]
+
+// pug comments (`//`) comment out their whole indented block
+function stripPugComments(src) {
+  const out = []
+  let commentIndent = -1
+  for (const line of src.split('\n')) {
+    const indent = line.match(/^\s*/)[0].length
+    const trimmed = line.trim()
+    if (commentIndent >= 0 && (trimmed === '' || indent > commentIndent)) continue
+    commentIndent = -1
+    if (trimmed.startsWith('//')) { commentIndent = indent; continue }
+    out.push(line)
+  }
+  return out.join('\n')
+}
+
+function usedTags(src) {
+  const tags = new Set()
+  // <soci-x ...> in html strings, createElement('soci-x'), and pug tag lines
+  for (const m of src.matchAll(/<(soci-[a-z][a-z-]*)/g)) tags.add(m[1])
+  for (const m of src.matchAll(/createElement\(['"`](soci-[a-z][a-z-]*)/g)) tags.add(m[1])
+  for (const m of src.matchAll(/^\s*(soci-[a-z][a-z-]*)[(.#\s]/gm)) tags.add(m[1])
+  return tags
+}
+
+test('every element referenced in templates and scripts is core-defined or registered', () => {
+  const missing = new Map()
+  for (const f of scanFiles) {
+    const src = f.endsWith('.pug') ? stripPugComments(read(f)) : read(f)
+    for (const tag of usedTags(src)) {
+      if (tag === 'soci-route' || known.has(tag)) continue
+      if (!missing.has(tag)) missing.set(tag, [])
+      missing.get(tag).push(f)
+    }
+  }
+  assert.deepEqual([...missing], [], `unregistered elements: ${JSON.stringify([...missing])}`)
+})
+
+test('every registry path resolves to a real module', () => {
+  for (const [name, rel] of Object.entries(REGISTRY)) {
+    const file = path.join(root, 'components', rel)
+    assert.ok(fs.existsSync(file), `${name} -> ${rel} does not exist`)
+  }
+})
+
+test('packs only name known elements', () => {
+  for (const [route, names] of Object.entries(PACKS)) {
+    for (const name of names) {
+      assert.ok(REGISTRY[name] || coreDefines.includes(name), `pack ${route} names unknown element ${name}`)
+    }
+  }
+  for (const [modal, names] of Object.entries(MODAL_PACKS)) {
+    for (const name of names) {
+      assert.ok(REGISTRY[name] || coreDefines.includes(name), `modal pack ${modal} names unknown element ${name}`)
+    }
+  }
+})
+
+test('every route in the shell has a pack entry', () => {
+  const routeIds = [...read('index.pug').matchAll(/soci-route#([\w-]+)/g)].map(m => m[1])
+  assert.ok(routeIds.length > 10, 'route extraction should find the shell routes')
+  for (const id of routeIds) {
+    assert.ok(id in PACKS, `route #${id} has no PACKS entry (add one, [] if it only uses core elements)`)
+  }
+})
+
+test('the eager core never statically imports a lazily registered module', () => {
+  const staticImports = [...componentsSrc.matchAll(/^import\s[^'"]*['"]([^'"]+)['"]/gm)].map(m => m[1])
+  const lazyPaths = new Set(Object.values(REGISTRY).map(p => p.replace(/^\.\//, '')))
+  for (const imp of staticImports) {
+    assert.ok(!lazyPaths.has(imp.replace(/^\.\//, '')), `core statically imports lazy module ${imp}`)
+  }
+})
+
+test('no element is both core-defined and lazily registered', () => {
+  for (const name of coreDefines) {
+    assert.ok(!(name in REGISTRY), `${name} is defined eagerly and present in the lazy registry`)
+  }
+})

--- a/speed-lab/harness/probe-lazy.mjs
+++ b/speed-lab/harness/probe-lazy.mjs
@@ -1,0 +1,81 @@
+// Verifies the lazy component graph: which /components|/lib modules load in
+// each phase (first paint vs idle warmup vs route enter), and that no phase
+// pulls modules it shouldn't. Throttled so the phases can't race each other.
+// Usage: node probe-lazy.mjs [base-url]
+
+import { chromium } from 'playwright'
+
+const BASE = process.argv[2] || 'http://localhost:4200'
+const POST_LINK_MODULES = ['soci-post.js', 'soci-comment.js', 'soci-comment-list.js']
+const FEED_MODULES = ['soci-post-list.js', 'soci-post-li.js', 'grid-lanes-polyfill.js']
+const HEAVY_LAZY = ['soci-text-channel-view-threaded.js', 'soci-avatar-uploader.js', 'soci-video-uploader.js', 'soci-ledger.js', 'soci-input.js', ...POST_LINK_MODULES]
+
+let failures = 0
+const check = (ok, label) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`)
+  if (!ok) failures++
+}
+const names = reqs => reqs.map(u => u.split('/').pop().split('?')[0])
+
+async function phase(page, throttle = true) {
+  if (throttle) {
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Network.enable')
+    await cdp.send('Network.emulateNetworkConditions', {
+      offline: false, latency: 40, downloadThroughput: 3_000_000 / 8, uploadThroughput: 1_000_000 / 8
+    })
+  }
+  const js = []
+  const errors = []
+  page.on('request', r => { const u = r.url(); if (/\/(components|lib)\/.*\.js/.test(u)) js.push(u) })
+  page.on('pageerror', e => errors.push(String(e)))
+  // Script errors only: 4xx console noise (e.g. anonymous /emojis/sets 401)
+  // predates the lazy graph and fires identically on master.
+  page.on('console', m => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errors.push(m.text()) })
+  return { js, errors }
+}
+
+const browser = await chromium.launch()
+
+{ // Phase 1+2: cold home -> feed paint, then idle warmup
+  const page = await browser.newPage()
+  const { js, errors } = await phase(page)
+  await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('soci-post-li', { state: 'attached', timeout: 30000 })
+  const atPaint = names(js)
+
+  check(FEED_MODULES.every(m => atPaint.includes(m)), `feed pack requested by feed paint (${atPaint.length} modules)`)
+  const leaked = HEAVY_LAZY.filter(m => atPaint.includes(m))
+  check(leaked.length === 0, `no off-route modules before feed paint${leaked.length ? ': ' + leaked : ''}`)
+
+  await page.waitForLoadState('load')
+  await page.waitForTimeout(6000)
+  const afterIdle = names(js)
+  check(POST_LINK_MODULES.every(m => afterIdle.includes(m)), `idle warmup fetched the deferred graph (${afterIdle.length} modules)`)
+
+  // Route enter still works end to end after warmup
+  await page.locator('soci-post-li #metadata-link').first().click()
+  await page.waitForSelector('soci-post[url]', { state: 'attached', timeout: 15000 })
+  await page.waitForSelector('soci-comment', { state: 'attached', timeout: 15000 })
+  check(true, 'feed -> post transition renders post and comments')
+  check(errors.length === 0, `no console/page errors on home${errors.length ? ': ' + errors[0] : ''}`)
+  await page.close()
+}
+
+{ // Phase 3: cold post deep link must not pull the feed pack before paint
+  const page = await browser.newPage()
+  const { js, errors } = await phase(page)
+  await page.goto(BASE + '/speed-lab-measured-post', { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('soci-comment', { state: 'attached', timeout: 30000 })
+  const atPaint = names(js)
+
+  check(POST_LINK_MODULES.every(m => atPaint.includes(m)), `post pack requested by post paint (${atPaint.length} modules)`)
+  const leaked = FEED_MODULES.filter(m => atPaint.includes(m))
+  check(leaked.length === 0, `no feed modules before post paint${leaked.length ? ': ' + leaked : ''}`)
+  check(errors.length === 0, `no console/page errors on deep link${errors.length ? ': ' + errors[0] : ''}`)
+  await page.close()
+}
+
+await browser.close()
+console.log(failures ? `\n${failures} check(s) FAILED` : '\nall checks passed')
+process.exit(failures ? 1 : 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Splits the loader half out of #172 so the first-paint win can be reviewed on its own. **Frontend only** — no backend routes, no websocket notifications, no `EDGE_PLAYBOOK.md`. #172 stays open and untouched for the websocket half.

10 files / +449 −174, against a fresh `master`, versus 24 files / +1362 −207 in #172.

## What changed

`soci-components.js` used to statically import all ~65 element modules (502 KB raw / 140 KB gz). ES module semantics mean nothing executes until the slowest import arrives, so every route paid for the whole graph before first paint. Now only the 17-module shell is eager (routing, sidebar, and the chrome primitives they slot); everything else is defined on demand.

- **`components/soci-loader.js`** (new) — element→module `REGISTRY`, per-route `PACKS` keyed by `soci-route` id, and `MODAL_PACKS`. `ensure()` de-dupes in-flight imports. A failed import resolves anyway so the route still activates, and forgets the attempt so a later `ensure()` retries instead of caching the failure forever.
- **`soci-route.js`** — `activate()` awaits `routeReady(this.id)` before setting `active` and dispatching `routeactivate`, so page scripts that call component methods never race `customElements.define`. An activation token discards a pack that lands after you've navigated away, and `deactivate()` now also cleans up a route still in its `activating` phase. This also removes the stale TODO block that hypothesized exactly this change.
- **Lazy-load trigger points** — modals via the modal manager's existing `load` hook, sidebar channel rows on first render, and the rest of the registry warming after `load` + idle so SPA navigations stay instant. Warmup is skipped under `saveData` and runs sequentially on purpose: a burst of 40 imports competes with lazy-loading feed media.
- **`soci.css`** — `#pages :not(:defined) { display: none }` keeps light-DOM children (e.g. submit's tab contents) from flashing unstyled before upgrade.
- **`quickStart.sh`** — carried along because the lazy graph can't be exercised without a running stack: CDN builds compile the whole package (`go build -o X .`) instead of just `main.go`. The cache-control helpers added in the earlier perf pass live in sibling files, so the old command no longer built.

## Measured

Seeded local stack (2,600 posts), slow4g CDP lane, medians of 7:

| | before | after | |
|---|---|---|---|
| home cold FCP | 2656 ms | 1348 ms | −49% |
| home cold LCP | 2716 ms | 1800 ms | −34% |
| home feedPaint | 3234 ms | 2266 ms | −30% |
| post deep link FCP | 2512 ms | 1332 ms | −47% |
| post deep link LCP | 2804 ms | 2056 ms | −27% |

Feed paint needs 31 modules instead of 68. Warm loads and SPA transitions are unchanged.

## Tests

`soci-frontend/test/loader.test.js` guards the split statically, so the graph can't silently rot: every element referenced in any template or script is either core-defined or registered, every registry path resolves to a real module, packs only name known elements, every `soci-route` id in the shell has a pack entry, the eager core never statically imports a lazily registered module, and no element is both eager and lazy.

`speed-lab/harness/probe-lazy.mjs` asserts the phase split in a real browser: the feed pack arrives by feed paint without dragging in off-route modules, idle warmup backfills the deferred graph, a cold post deep link paints without the feed pack, and feed → post still renders after warmup.

`npm test` in `soci-frontend`: 18/18 green.

## Runtime verification on this branch

The static tests can't prove the modules actually import, so this branch was also exercised in headless Chromium against the real frontend server. No backend was available in the sandbox (no MySQL), so API fetches reject — that is pre-existing and independent of module loading. Results:

- All **45** registry entries import and reach `customElements.define` — every path resolves and every transitive import chain evaluates, with no 4xx/5xx on any module request.
- All **20** route packs and all **5** modal packs resolve through `routeReady()` / `ensure()`.
- The eager graph before the `load` event is **31 modules** (independently reproducing the number claimed above, down from 68). It contains the home route's own feed pack, as intended, and none of the off-route modules (`soci-comment`, `soci-comment-list`, `soci-ledger`, `soci-avatar-uploader`, `soci-video-uploader`, `soci-text-channel-view-threaded`, `soci-password`, `soci-login-modal`).
- `routeactivate` fires only once every element in the route's pack is defined, confirming page scripts can't race `customElements.define`.
- Repeat `ensure()` of an already-loaded module issues no new network fetch.
- Unknown element names, unknown route ids, and `ensure(undefined)` all resolve instead of throwing.
- No script errors other than the absent-backend fetch failures.

## Not in this PR

The websocket notification work from #172 (`/notifications/ws`, the per-user hub, `soci-notification-badge` subscribing instead of polling, `api.wsUrl` consolidation, the Go ws tests, `probe-notifications-ws.mjs`) and `speed-lab/EDGE_PLAYBOOK.md`. Nothing here references any of it, and thumbnail srcset/HEIC handling plus every other speed keeper on `master` are untouched.

Do not merge #172 as a duplicate of this — land this one, then rebase #172 down to just the websocket commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72601f70-ff80-4132-9819-c20668b45cc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72601f70-ff80-4132-9819-c20668b45cc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

